### PR TITLE
Dublin Bikes chart and text improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,17 +90,24 @@ if (app.get('env') === 'development') {
  ************/
 let bikesQuery = require("./services/derilinx-api-query.js");
 
-//Every night at 3.45 am
-cron.schedule('45 3 * * *', () => {
+//Every 30 minutes
+cron.schedule('*/10 * * * *', () => {
   util.log(`\n\nRunning bikes cron\n\n`);
 
   //Generating date queries to GET each night in cron
-  const yesterdayStart = moment.utc().subtract(1, 'days').startOf('day');
-  const yesterdayEnd = moment.utc().subtract(1, 'days').endOf('day');
-  const weekStart = moment.utc().subtract(1, 'weeks').startOf('day');
-  const monthStart = moment.utc().subtract(1, 'months').startOf('day');
+  const now = moment.utc();
+  //const yesterdayStart = moment.utc().subtract(1, 'days').startOf('day');
+  //const yesterdayEnd = moment.utc().subtract(1, 'days').endOf('day');
+  //const weekStart = moment.utc().subtract(1, 'weeks').startOf('day');
+  //const monthStart = moment.utc().subtract(1, 'months').startOf('day');
 
-  bikesQuery.getAllStationsDataHourly(yesterdayStart, yesterdayEnd)
+  const yesterdayStart = moment.utc().subtract(1, 'days');
+  const yesterdayEnd = moment.utc().subtract(1, 'days').endOf('day');
+  const weekStart = moment.utc().subtract(1, 'weeks');
+  const monthStart = moment.utc().subtract(1, 'months');
+
+
+  bikesQuery.getAllStationsDataHourly(yesterdayStart, now)
     .then((data) => {
       if (data.length >= 1) {
         const e = new moment(yesterdayEnd);
@@ -126,7 +133,7 @@ cron.schedule('45 3 * * *', () => {
       util.log("\n\n Handling errror " + err);
     });
 
-  bikesQuery.getAllStationsDataHourly(weekStart, yesterdayEnd)
+  bikesQuery.getAllStationsDataHourly(weekStart, now)
     .then((data) => {
       if (data.length >= 1) {
         const e = new moment(weekStart);
@@ -152,7 +159,7 @@ cron.schedule('45 3 * * *', () => {
       util.log("\n\n Handling errror " + err);
     });
 
-  bikesQuery.getAllStationsDataHourly(monthStart, yesterdayEnd)
+  bikesQuery.getAllStationsDataHourly(monthStart, now)
     .then((data) => {
       if (data.length >= 1) {
         const e = new moment(monthStart);

--- a/public/data/Transport/dublinBikes/day.json
+++ b/public/data/Transport/dublinBikes/day.json
@@ -1,170 +1,177 @@
 [
   {
-    "date": "2019-09-22T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1419,
-    "label": "3am, Sunday September 22nd",
+    "date": "2019-10-24T16:30:02.000Z",
+    "Bikes in use": 174,
+    "Bikes available": 1203,
+    "label": "12pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1419,
-    "label": "4am, Sunday September 22nd",
+    "date": "2019-10-24T17:30:03.000Z",
+    "Bikes in use": 229,
+    "Bikes available": 1148,
+    "label": "1pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T05:00:02.000Z",
-    "Bikes in use": 4,
-    "Bikes available": 1415,
-    "label": "5am, Sunday September 22nd",
+    "date": "2019-10-24T18:30:02.000Z",
+    "Bikes in use": 133,
+    "Bikes available": 1244,
+    "label": "2pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T06:00:02.000Z",
-    "Bikes in use": 1,
-    "Bikes available": 1418,
-    "label": "6am, Sunday September 22nd",
+    "date": "2019-10-24T19:30:02.000Z",
+    "Bikes in use": 51,
+    "Bikes available": 1326,
+    "label": "3pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T07:00:02.000Z",
-    "Bikes in use": 4,
-    "Bikes available": 1415,
-    "label": "7am, Sunday September 22nd",
+    "date": "2019-10-24T20:30:02.000Z",
+    "Bikes in use": 48,
+    "Bikes available": 1329,
+    "label": "4pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T08:00:03.000Z",
-    "Bikes in use": 12,
-    "Bikes available": 1407,
-    "label": "8am, Sunday September 22nd",
+    "date": "2019-10-24T21:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "5pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T09:00:03.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1400,
-    "label": "9am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T10:00:03.000Z",
-    "Bikes in use": 52,
-    "Bikes available": 1367,
-    "label": "10am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T11:00:03.000Z",
-    "Bikes in use": 63,
-    "Bikes available": 1356,
-    "label": "11am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T12:00:03.000Z",
-    "Bikes in use": 77,
-    "Bikes available": 1342,
-    "label": "12pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T13:00:03.000Z",
-    "Bikes in use": 98,
-    "Bikes available": 1321,
-    "label": "1pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T14:00:02.000Z",
-    "Bikes in use": 86,
-    "Bikes available": 1333,
-    "label": "2pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T15:00:02.000Z",
-    "Bikes in use": 111,
-    "Bikes available": 1308,
-    "label": "3pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T16:00:02.000Z",
-    "Bikes in use": 94,
-    "Bikes available": 1325,
-    "label": "4pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T17:00:02.000Z",
-    "Bikes in use": 98,
-    "Bikes available": 1321,
-    "label": "5pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T18:00:03.000Z",
-    "Bikes in use": 55,
-    "Bikes available": 1364,
-    "label": "6pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T19:00:02.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1409,
-    "label": "7pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T20:00:02.000Z",
+    "date": "2019-10-24T22:30:02.000Z",
     "Bikes in use": 21,
-    "Bikes available": 1398,
-    "label": "8pm, Sunday September 22nd",
+    "Bikes available": 1356,
+    "label": "6pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T21:00:03.000Z",
-    "Bikes in use": 23,
-    "Bikes available": 1396,
-    "label": "9pm, Sunday September 22nd",
+    "date": "2019-10-24T23:30:03.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "7pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T22:00:03.000Z",
-    "Bikes in use": 9,
-    "Bikes available": 1410,
-    "label": "10pm, Sunday September 22nd",
+    "date": "2019-10-25T00:30:02.000Z",
+    "Bikes in use": 2,
+    "Bikes available": 1375,
+    "label": "8pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T23:00:02.000Z",
-    "Bikes in use": 17,
-    "Bikes available": 1402,
-    "label": "11pm, Sunday September 22nd",
+    "date": "2019-10-25T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "9pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T00:00:03.000Z",
-    "Bikes in use": 7,
-    "Bikes available": 1412,
-    "label": "12am, Monday September 23rd",
+    "date": "2019-10-25T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "10pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T01:00:03.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1414,
-    "label": "1am, Monday September 23rd",
+    "date": "2019-10-25T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "11pm, Thursday October 24th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T02:00:02.000Z",
-    "Bikes in use": 4,
-    "Bikes available": 1415,
-    "label": "2am, Monday September 23rd",
+    "date": "2019-10-25T04:30:02.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "12am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T05:30:02.000Z",
+    "Bikes in use": 54,
+    "Bikes available": 1323,
+    "label": "1am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T06:30:02.000Z",
+    "Bikes in use": 110,
+    "Bikes available": 1267,
+    "label": "2am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T07:30:02.000Z",
+    "Bikes in use": 309,
+    "Bikes available": 1068,
+    "label": "3am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T08:30:02.000Z",
+    "Bikes in use": 136,
+    "Bikes available": 1241,
+    "label": "4am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T09:30:02.000Z",
+    "Bikes in use": 60,
+    "Bikes available": 1317,
+    "label": "5am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T10:30:02.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "6am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T11:30:02.000Z",
+    "Bikes in use": 76,
+    "Bikes available": 1301,
+    "label": "7am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T12:30:02.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "8am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T13:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "9am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T14:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "10am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T15:30:02.000Z",
+    "Bikes in use": 105,
+    "Bikes available": 1272,
+    "label": "11am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T16:30:02.000Z",
+    "Bikes in use": 115,
+    "Bikes available": 1262,
+    "label": "12pm, Friday October 25th",
     "year": "2019"
   }
 ]

--- a/public/data/Transport/dublinBikes/month.json
+++ b/public/data/Transport/dublinBikes/month.json
@@ -1,5196 +1,5049 @@
 [
   {
-    "date": "2019-08-23T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "3am, Friday August 23rd",
+    "date": "2019-09-25T16:30:02.000Z",
+    "Bikes in use": 292,
+    "Bikes available": 1085,
+    "label": "12pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-08-23T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "4am, Friday August 23rd",
+    "date": "2019-09-25T17:30:03.000Z",
+    "Bikes in use": 233,
+    "Bikes available": 1144,
+    "label": "1pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-08-23T05:00:03.000Z",
-    "Bikes in use": 33,
-    "Bikes available": 1344,
-    "label": "5am, Friday August 23rd",
+    "date": "2019-09-25T18:30:03.000Z",
+    "Bikes in use": 127,
+    "Bikes available": 1250,
+    "label": "2pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-08-23T06:00:02.000Z",
-    "Bikes in use": 118,
-    "Bikes available": 1259,
-    "label": "6am, Friday August 23rd",
+    "date": "2019-09-25T19:30:03.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "3pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-08-23T07:00:02.000Z",
-    "Bikes in use": 266,
-    "Bikes available": 1111,
-    "label": "7am, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T08:00:03.000Z",
-    "Bikes in use": 283,
-    "Bikes available": 1094,
-    "label": "8am, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T09:00:02.000Z",
-    "Bikes in use": 107,
-    "Bikes available": 1270,
-    "label": "9am, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T10:00:02.000Z",
-    "Bikes in use": 69,
-    "Bikes available": 1308,
-    "label": "10am, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T11:00:02.000Z",
-    "Bikes in use": 107,
-    "Bikes available": 1270,
-    "label": "11am, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T12:00:02.000Z",
-    "Bikes in use": 187,
-    "Bikes available": 1190,
-    "label": "12pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T13:00:02.000Z",
-    "Bikes in use": 144,
-    "Bikes available": 1233,
-    "label": "1pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T14:00:02.000Z",
-    "Bikes in use": 113,
-    "Bikes available": 1264,
-    "label": "2pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T15:00:03.000Z",
-    "Bikes in use": 119,
-    "Bikes available": 1258,
-    "label": "3pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T16:00:02.000Z",
-    "Bikes in use": 257,
-    "Bikes available": 1120,
-    "label": "4pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T17:00:02.000Z",
-    "Bikes in use": 276,
-    "Bikes available": 1101,
-    "label": "5pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T18:00:02.000Z",
-    "Bikes in use": 142,
-    "Bikes available": 1235,
-    "label": "6pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T19:00:02.000Z",
-    "Bikes in use": 97,
-    "Bikes available": 1280,
-    "label": "7pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T20:00:02.000Z",
-    "Bikes in use": 58,
-    "Bikes available": 1319,
-    "label": "8pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T21:00:03.000Z",
-    "Bikes in use": 40,
-    "Bikes available": 1337,
-    "label": "9pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T22:00:02.000Z",
-    "Bikes in use": 8,
-    "Bikes available": 1369,
-    "label": "10pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-23T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1382,
-    "label": "11pm, Friday August 23rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1394,
-    "label": "12am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1401,
-    "label": "1am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "2am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1410,
-    "label": "3am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1410,
-    "label": "4am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T05:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1405,
-    "label": "5am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T06:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1388,
-    "label": "6am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T07:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "7am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T08:00:02.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1367,
-    "label": "8am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T09:00:02.000Z",
-    "Bikes in use": 46,
-    "Bikes available": 1331,
-    "label": "9am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T10:00:03.000Z",
-    "Bikes in use": 82,
-    "Bikes available": 1295,
-    "label": "10am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T11:00:03.000Z",
-    "Bikes in use": 100,
-    "Bikes available": 1277,
-    "label": "11am, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T12:00:02.000Z",
-    "Bikes in use": 94,
-    "Bikes available": 1283,
-    "label": "12pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T13:00:02.000Z",
-    "Bikes in use": 108,
-    "Bikes available": 1269,
-    "label": "1pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T14:00:02.000Z",
-    "Bikes in use": 144,
-    "Bikes available": 1233,
-    "label": "2pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T15:00:03.000Z",
-    "Bikes in use": 92,
-    "Bikes available": 1285,
-    "label": "3pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T16:00:02.000Z",
-    "Bikes in use": 74,
-    "Bikes available": 1303,
-    "label": "4pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T17:00:03.000Z",
-    "Bikes in use": 31,
-    "Bikes available": 1346,
-    "label": "5pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T18:00:03.000Z",
-    "Bikes in use": 50,
-    "Bikes available": 1327,
-    "label": "6pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T19:00:02.000Z",
-    "Bikes in use": 39,
-    "Bikes available": 1338,
-    "label": "7pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T20:00:03.000Z",
-    "Bikes in use": 6,
-    "Bikes available": 1371,
-    "label": "8pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T21:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1381,
-    "label": "9pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T22:00:02.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "10pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-24T23:00:02.000Z",
-    "Bikes in use": 7,
-    "Bikes available": 1370,
-    "label": "11pm, Saturday August 24th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1393,
-    "label": "12am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1408,
-    "label": "1am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "2am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "3am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "4am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T05:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1408,
-    "label": "5am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T06:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1401,
-    "label": "6am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T07:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1403,
-    "label": "7am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T08:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1393,
-    "label": "8am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T09:00:03.000Z",
-    "Bikes in use": 2,
-    "Bikes available": 1375,
-    "label": "9am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T10:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "10am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T11:00:02.000Z",
-    "Bikes in use": 64,
-    "Bikes available": 1313,
-    "label": "11am, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T12:00:02.000Z",
-    "Bikes in use": 84,
-    "Bikes available": 1293,
-    "label": "12pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T13:00:02.000Z",
-    "Bikes in use": 104,
-    "Bikes available": 1273,
-    "label": "1pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T14:00:02.000Z",
-    "Bikes in use": 117,
-    "Bikes available": 1260,
-    "label": "2pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T15:00:02.000Z",
-    "Bikes in use": 82,
-    "Bikes available": 1295,
-    "label": "3pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T16:00:02.000Z",
-    "Bikes in use": 107,
-    "Bikes available": 1270,
-    "label": "4pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T17:00:02.000Z",
-    "Bikes in use": 105,
-    "Bikes available": 1272,
-    "label": "5pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T18:00:02.000Z",
-    "Bikes in use": 74,
-    "Bikes available": 1303,
-    "label": "6pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T19:00:02.000Z",
-    "Bikes in use": 65,
-    "Bikes available": 1312,
-    "label": "7pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T20:00:03.000Z",
-    "Bikes in use": 35,
-    "Bikes available": 1342,
-    "label": "8pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T21:00:02.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "9pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1379,
-    "label": "10pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-25T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "11pm, Sunday August 25th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T00:00:02.000Z",
+    "date": "2019-09-25T20:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1397,
-    "label": "12am, Monday August 26th",
+    "label": "4pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-08-26T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1401,
-    "label": "1am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "2am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "3am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "4am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T05:00:02.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1358,
-    "label": "5am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T06:00:02.000Z",
-    "Bikes in use": 64,
-    "Bikes available": 1313,
-    "label": "6am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T07:00:02.000Z",
-    "Bikes in use": 228,
-    "Bikes available": 1149,
-    "label": "7am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T08:00:02.000Z",
-    "Bikes in use": 324,
-    "Bikes available": 1053,
-    "label": "8am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T09:00:03.000Z",
-    "Bikes in use": 128,
-    "Bikes available": 1249,
-    "label": "9am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T10:00:02.000Z",
-    "Bikes in use": 95,
-    "Bikes available": 1282,
-    "label": "10am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T11:00:03.000Z",
-    "Bikes in use": 83,
-    "Bikes available": 1294,
-    "label": "11am, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T12:00:03.000Z",
-    "Bikes in use": 204,
-    "Bikes available": 1173,
-    "label": "12pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T13:00:03.000Z",
-    "Bikes in use": 168,
-    "Bikes available": 1209,
-    "label": "1pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T14:00:02.000Z",
-    "Bikes in use": 79,
-    "Bikes available": 1298,
-    "label": "2pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T15:00:03.000Z",
-    "Bikes in use": 101,
-    "Bikes available": 1276,
-    "label": "3pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T16:00:02.000Z",
-    "Bikes in use": 236,
-    "Bikes available": 1141,
-    "label": "4pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T17:00:03.000Z",
-    "Bikes in use": 332,
-    "Bikes available": 1045,
-    "label": "5pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T18:00:03.000Z",
-    "Bikes in use": 197,
-    "Bikes available": 1180,
-    "label": "6pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T19:00:02.000Z",
-    "Bikes in use": 115,
-    "Bikes available": 1262,
-    "label": "7pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T20:00:02.000Z",
-    "Bikes in use": 60,
-    "Bikes available": 1317,
-    "label": "8pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T21:00:02.000Z",
-    "Bikes in use": 44,
-    "Bikes available": 1333,
-    "label": "9pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T22:00:02.000Z",
-    "Bikes in use": 2,
-    "Bikes available": 1375,
-    "label": "10pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-26T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1383,
-    "label": "11pm, Monday August 26th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1389,
-    "label": "12am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1391,
-    "label": "1am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1394,
-    "label": "2am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1394,
-    "label": "3am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "4am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T05:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1392,
-    "label": "5am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T06:00:02.000Z",
-    "Bikes in use": 74,
-    "Bikes available": 1303,
-    "label": "6am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T07:00:02.000Z",
-    "Bikes in use": 300,
-    "Bikes available": 1077,
-    "label": "7am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T08:00:03.000Z",
-    "Bikes in use": 340,
-    "Bikes available": 1037,
-    "label": "8am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T09:00:02.000Z",
-    "Bikes in use": 117,
-    "Bikes available": 1260,
-    "label": "9am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T10:00:02.000Z",
-    "Bikes in use": 74,
-    "Bikes available": 1303,
-    "label": "10am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T11:00:02.000Z",
-    "Bikes in use": 103,
-    "Bikes available": 1274,
-    "label": "11am, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T12:00:03.000Z",
-    "Bikes in use": 200,
-    "Bikes available": 1177,
-    "label": "12pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T13:00:02.000Z",
-    "Bikes in use": 175,
-    "Bikes available": 1202,
-    "label": "1pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T14:00:02.000Z",
-    "Bikes in use": 116,
-    "Bikes available": 1261,
-    "label": "2pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T15:00:02.000Z",
-    "Bikes in use": 136,
-    "Bikes available": 1241,
-    "label": "3pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T16:00:02.000Z",
-    "Bikes in use": 258,
-    "Bikes available": 1119,
-    "label": "4pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T17:00:02.000Z",
-    "Bikes in use": 350,
-    "Bikes available": 1027,
-    "label": "5pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T18:00:02.000Z",
-    "Bikes in use": 208,
-    "Bikes available": 1169,
-    "label": "6pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T19:00:02.000Z",
-    "Bikes in use": 95,
-    "Bikes available": 1282,
-    "label": "7pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T20:00:02.000Z",
-    "Bikes in use": 48,
-    "Bikes available": 1329,
-    "label": "8pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T21:00:03.000Z",
-    "Bikes in use": 46,
-    "Bikes available": 1331,
-    "label": "9pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T22:00:02.000Z",
-    "Bikes in use": 13,
-    "Bikes available": 1364,
-    "label": "10pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-27T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1382,
-    "label": "11pm, Tuesday August 27th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1392,
-    "label": "12am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "1am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1396,
-    "label": "2am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1398,
-    "label": "3am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1399,
-    "label": "4am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "5am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T06:00:02.000Z",
-    "Bikes in use": 46,
-    "Bikes available": 1331,
-    "label": "6am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T07:00:02.000Z",
-    "Bikes in use": 283,
-    "Bikes available": 1094,
-    "label": "7am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T08:00:27.000Z",
-    "Bikes in use": 372,
-    "Bikes available": 1005,
-    "label": "8am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T09:00:03.000Z",
-    "Bikes in use": 108,
-    "Bikes available": 1269,
-    "label": "9am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T10:00:02.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1278,
-    "label": "10am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T11:00:02.000Z",
-    "Bikes in use": 103,
-    "Bikes available": 1274,
-    "label": "11am, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T12:00:02.000Z",
-    "Bikes in use": 194,
-    "Bikes available": 1183,
-    "label": "12pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T13:00:03.000Z",
-    "Bikes in use": 157,
-    "Bikes available": 1220,
-    "label": "1pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T14:00:03.000Z",
-    "Bikes in use": 70,
-    "Bikes available": 1307,
-    "label": "2pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T15:00:02.000Z",
-    "Bikes in use": 81,
-    "Bikes available": 1296,
-    "label": "3pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T16:00:02.000Z",
-    "Bikes in use": 216,
-    "Bikes available": 1161,
-    "label": "4pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T17:00:02.000Z",
-    "Bikes in use": 334,
-    "Bikes available": 1043,
-    "label": "5pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T18:00:02.000Z",
-    "Bikes in use": 202,
-    "Bikes available": 1175,
-    "label": "6pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T19:00:03.000Z",
-    "Bikes in use": 101,
-    "Bikes available": 1276,
-    "label": "7pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T20:00:02.000Z",
-    "Bikes in use": 58,
-    "Bikes available": 1319,
-    "label": "8pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T21:00:02.000Z",
-    "Bikes in use": 29,
-    "Bikes available": 1348,
-    "label": "9pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T22:00:02.000Z",
-    "Bikes in use": 9,
-    "Bikes available": 1368,
-    "label": "10pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-28T23:00:02.000Z",
-    "Bikes in use": 2,
-    "Bikes available": 1375,
-    "label": "11pm, Wednesday August 28th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1388,
-    "label": "12am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1393,
-    "label": "1am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "2am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "3am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "4am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1380,
-    "label": "5am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T06:00:03.000Z",
-    "Bikes in use": 61,
-    "Bikes available": 1316,
-    "label": "6am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T07:00:02.000Z",
-    "Bikes in use": 229,
-    "Bikes available": 1148,
-    "label": "7am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T08:00:02.000Z",
-    "Bikes in use": 363,
-    "Bikes available": 1014,
-    "label": "8am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T09:00:02.000Z",
-    "Bikes in use": 110,
-    "Bikes available": 1267,
-    "label": "9am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T10:00:02.000Z",
-    "Bikes in use": 108,
-    "Bikes available": 1269,
-    "label": "10am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T11:00:02.000Z",
-    "Bikes in use": 87,
-    "Bikes available": 1290,
-    "label": "11am, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T12:00:02.000Z",
-    "Bikes in use": 186,
-    "Bikes available": 1191,
-    "label": "12pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T13:00:02.000Z",
-    "Bikes in use": 161,
-    "Bikes available": 1216,
-    "label": "1pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T14:00:02.000Z",
-    "Bikes in use": 71,
-    "Bikes available": 1306,
-    "label": "2pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T15:00:02.000Z",
-    "Bikes in use": 101,
-    "Bikes available": 1276,
-    "label": "3pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T16:00:02.000Z",
-    "Bikes in use": 209,
-    "Bikes available": 1168,
-    "label": "4pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T17:00:02.000Z",
-    "Bikes in use": 254,
-    "Bikes available": 1123,
-    "label": "5pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T18:00:02.000Z",
-    "Bikes in use": 179,
-    "Bikes available": 1198,
-    "label": "6pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T19:00:02.000Z",
-    "Bikes in use": 103,
-    "Bikes available": 1274,
-    "label": "7pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T20:00:02.000Z",
-    "Bikes in use": 57,
-    "Bikes available": 1320,
-    "label": "8pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T21:00:02.000Z",
-    "Bikes in use": 54,
-    "Bikes available": 1323,
-    "label": "9pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T22:00:02.000Z",
-    "Bikes in use": 24,
-    "Bikes available": 1353,
-    "label": "10pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-29T23:00:03.000Z",
-    "Bikes in use": 25,
-    "Bikes available": 1352,
-    "label": "11pm, Thursday August 29th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1379,
-    "label": "12am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1384,
-    "label": "1am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "2am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "3am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "4am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T05:00:02.000Z",
-    "Bikes in use": 12,
-    "Bikes available": 1365,
-    "label": "5am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T06:00:03.000Z",
-    "Bikes in use": 70,
-    "Bikes available": 1307,
-    "label": "6am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T07:00:03.000Z",
-    "Bikes in use": 201,
-    "Bikes available": 1176,
-    "label": "7am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T08:00:02.000Z",
-    "Bikes in use": 339,
-    "Bikes available": 1038,
-    "label": "8am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T09:00:02.000Z",
-    "Bikes in use": 96,
-    "Bikes available": 1281,
-    "label": "9am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T10:00:02.000Z",
-    "Bikes in use": 98,
-    "Bikes available": 1279,
-    "label": "10am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T11:00:02.000Z",
-    "Bikes in use": 88,
-    "Bikes available": 1289,
-    "label": "11am, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T12:00:02.000Z",
-    "Bikes in use": 193,
-    "Bikes available": 1184,
-    "label": "12pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T13:00:03.000Z",
-    "Bikes in use": 132,
-    "Bikes available": 1245,
-    "label": "1pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T14:00:02.000Z",
-    "Bikes in use": 96,
-    "Bikes available": 1281,
-    "label": "2pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T15:00:02.000Z",
-    "Bikes in use": 128,
-    "Bikes available": 1249,
-    "label": "3pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T16:00:02.000Z",
-    "Bikes in use": 251,
-    "Bikes available": 1126,
-    "label": "4pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T17:00:02.000Z",
-    "Bikes in use": 289,
-    "Bikes available": 1088,
-    "label": "5pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T18:00:03.000Z",
-    "Bikes in use": 154,
-    "Bikes available": 1223,
-    "label": "6pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T19:00:02.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1278,
-    "label": "7pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T20:00:02.000Z",
-    "Bikes in use": 47,
-    "Bikes available": 1330,
-    "label": "8pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T21:00:03.000Z",
-    "Bikes in use": 39,
-    "Bikes available": 1338,
-    "label": "9pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T22:00:02.000Z",
-    "Bikes in use": 24,
-    "Bikes available": 1353,
-    "label": "10pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-30T23:00:02.000Z",
-    "Bikes in use": 18,
-    "Bikes available": 1359,
-    "label": "11pm, Friday August 30th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1382,
-    "label": "12am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1389,
-    "label": "1am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1394,
-    "label": "2am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1395,
-    "label": "3am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1396,
-    "label": "4am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T05:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1389,
-    "label": "5am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T06:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1383,
-    "label": "6am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T07:00:03.000Z",
+    "date": "2019-09-25T21:30:03.000Z",
     "Bikes in use": 10,
     "Bikes available": 1367,
-    "label": "7am, Saturday August 31st",
+    "label": "5pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-08-31T08:00:02.000Z",
-    "Bikes in use": 3,
-    "Bikes available": 1374,
-    "label": "8am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T09:00:03.000Z",
-    "Bikes in use": 35,
-    "Bikes available": 1342,
-    "label": "9am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T10:00:03.000Z",
-    "Bikes in use": 73,
-    "Bikes available": 1304,
-    "label": "10am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T11:00:02.000Z",
-    "Bikes in use": 64,
-    "Bikes available": 1313,
-    "label": "11am, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T12:00:03.000Z",
-    "Bikes in use": 118,
-    "Bikes available": 1259,
-    "label": "12pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T13:00:02.000Z",
-    "Bikes in use": 89,
-    "Bikes available": 1288,
-    "label": "1pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T14:00:02.000Z",
-    "Bikes in use": 93,
-    "Bikes available": 1284,
-    "label": "2pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T15:00:02.000Z",
-    "Bikes in use": 94,
-    "Bikes available": 1283,
-    "label": "3pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T16:00:02.000Z",
-    "Bikes in use": 82,
-    "Bikes available": 1295,
-    "label": "4pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T17:00:02.000Z",
-    "Bikes in use": 92,
-    "Bikes available": 1285,
-    "label": "5pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T18:00:02.000Z",
-    "Bikes in use": 61,
-    "Bikes available": 1316,
-    "label": "6pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T19:00:03.000Z",
-    "Bikes in use": 46,
-    "Bikes available": 1331,
-    "label": "7pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T20:00:02.000Z",
-    "Bikes in use": 16,
-    "Bikes available": 1361,
-    "label": "8pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T21:00:02.000Z",
-    "Bikes in use": 13,
-    "Bikes available": 1364,
-    "label": "9pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T22:00:02.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "10pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-08-31T23:00:02.000Z",
-    "Bikes in use": 6,
-    "Bikes available": 1371,
-    "label": "11pm, Saturday August 31st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1389,
-    "label": "12am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1394,
-    "label": "1am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1396,
-    "label": "2am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1396,
-    "label": "3am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1396,
-    "label": "4am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1394,
-    "label": "5am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T06:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "6am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T07:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "7am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T08:00:02.000Z",
+    "date": "2019-09-25T22:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1387,
-    "label": "8am, Sunday September 1st",
+    "label": "6pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-09-01T09:00:02.000Z",
-    "Bikes in use": 14,
-    "Bikes available": 1363,
-    "label": "9am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T10:00:03.000Z",
-    "Bikes in use": 45,
-    "Bikes available": 1332,
-    "label": "10am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T11:00:02.000Z",
-    "Bikes in use": 114,
-    "Bikes available": 1263,
-    "label": "11am, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T12:00:02.000Z",
-    "Bikes in use": 104,
-    "Bikes available": 1273,
-    "label": "12pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T13:00:02.000Z",
-    "Bikes in use": 100,
-    "Bikes available": 1277,
-    "label": "1pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T14:00:02.000Z",
-    "Bikes in use": 109,
-    "Bikes available": 1268,
-    "label": "2pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T15:00:03.000Z",
-    "Bikes in use": 94,
-    "Bikes available": 1283,
-    "label": "3pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T16:00:03.000Z",
-    "Bikes in use": 75,
-    "Bikes available": 1302,
-    "label": "4pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T17:00:02.000Z",
-    "Bikes in use": 77,
-    "Bikes available": 1300,
-    "label": "5pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T18:00:02.000Z",
-    "Bikes in use": 78,
-    "Bikes available": 1299,
-    "label": "6pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T19:00:02.000Z",
-    "Bikes in use": 49,
-    "Bikes available": 1328,
-    "label": "7pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T20:00:02.000Z",
-    "Bikes in use": 20,
-    "Bikes available": 1357,
-    "label": "8pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T21:00:03.000Z",
-    "Bikes in use": 12,
-    "Bikes available": 1365,
-    "label": "9pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T22:00:03.000Z",
-    "Bikes in use": 31,
-    "Bikes available": 1346,
-    "label": "10pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-01T23:00:02.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1367,
-    "label": "11pm, Sunday September 1st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T00:00:03.000Z",
+    "date": "2019-09-25T23:30:02.000Z",
     "Bikes in use": 0,
-    "Bikes available": 1380,
-    "label": "12am, Monday September 2nd",
+    "Bikes available": 1396,
+    "label": "7pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-09-02T01:00:03.000Z",
-    "Bikes in use": 3,
-    "Bikes available": 1374,
-    "label": "1am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T02:00:02.000Z",
-    "Bikes in use": 7,
-    "Bikes available": 1370,
-    "label": "2am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T03:00:03.000Z",
+    "date": "2019-09-26T00:30:02.000Z",
     "Bikes in use": 0,
-    "Bikes available": 1379,
-    "label": "3am, Monday September 2nd",
+    "Bikes available": 1407,
+    "label": "8pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-09-02T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1388,
-    "label": "4am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T05:00:02.000Z",
-    "Bikes in use": 35,
-    "Bikes available": 1342,
-    "label": "5am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T06:00:03.000Z",
-    "Bikes in use": 123,
-    "Bikes available": 1254,
-    "label": "6am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T07:00:02.000Z",
-    "Bikes in use": 236,
-    "Bikes available": 1141,
-    "label": "7am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T08:00:02.000Z",
-    "Bikes in use": 293,
-    "Bikes available": 1084,
-    "label": "8am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T09:00:02.000Z",
-    "Bikes in use": 152,
-    "Bikes available": 1225,
-    "label": "9am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T10:00:03.000Z",
-    "Bikes in use": 106,
-    "Bikes available": 1271,
-    "label": "10am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T11:00:03.000Z",
-    "Bikes in use": 80,
-    "Bikes available": 1297,
-    "label": "11am, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T12:00:02.000Z",
-    "Bikes in use": 123,
-    "Bikes available": 1254,
-    "label": "12pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T13:00:02.000Z",
-    "Bikes in use": 60,
-    "Bikes available": 1317,
-    "label": "1pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T14:00:03.000Z",
-    "Bikes in use": 60,
-    "Bikes available": 1317,
-    "label": "2pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T15:00:03.000Z",
-    "Bikes in use": 76,
-    "Bikes available": 1301,
-    "label": "3pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T16:00:03.000Z",
-    "Bikes in use": 208,
-    "Bikes available": 1169,
-    "label": "4pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T17:00:02.000Z",
-    "Bikes in use": 263,
-    "Bikes available": 1114,
-    "label": "5pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T18:00:02.000Z",
-    "Bikes in use": 140,
-    "Bikes available": 1237,
-    "label": "6pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T19:00:02.000Z",
-    "Bikes in use": 87,
-    "Bikes available": 1290,
-    "label": "7pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T20:00:02.000Z",
-    "Bikes in use": 40,
-    "Bikes available": 1337,
-    "label": "8pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T21:00:02.000Z",
-    "Bikes in use": 33,
-    "Bikes available": 1344,
-    "label": "9pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T22:00:02.000Z",
-    "Bikes in use": 8,
-    "Bikes available": 1369,
-    "label": "10pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-02T23:00:02.000Z",
-    "Bikes in use": 14,
-    "Bikes available": 1363,
-    "label": "11pm, Monday September 2nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T00:00:02.000Z",
-    "Bikes in use": 7,
-    "Bikes available": 1370,
-    "label": "12am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T01:00:02.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "1am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T02:00:03.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "2am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T03:00:03.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "3am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T04:00:03.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "4am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T05:00:02.000Z",
-    "Bikes in use": 23,
-    "Bikes available": 1354,
-    "label": "5am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T06:00:03.000Z",
-    "Bikes in use": 112,
-    "Bikes available": 1265,
-    "label": "6am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T07:00:03.000Z",
-    "Bikes in use": 261,
-    "Bikes available": 1116,
-    "label": "7am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T08:00:03.000Z",
-    "Bikes in use": 375,
-    "Bikes available": 1002,
-    "label": "8am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T09:00:02.000Z",
-    "Bikes in use": 168,
-    "Bikes available": 1209,
-    "label": "9am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T10:00:02.000Z",
-    "Bikes in use": 155,
-    "Bikes available": 1222,
-    "label": "10am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T11:00:03.000Z",
-    "Bikes in use": 111,
-    "Bikes available": 1266,
-    "label": "11am, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T12:00:03.000Z",
-    "Bikes in use": 235,
-    "Bikes available": 1142,
-    "label": "12pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T13:00:02.000Z",
-    "Bikes in use": 186,
-    "Bikes available": 1191,
-    "label": "1pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T14:00:03.000Z",
-    "Bikes in use": 104,
-    "Bikes available": 1273,
-    "label": "2pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T15:00:02.000Z",
-    "Bikes in use": 132,
-    "Bikes available": 1245,
-    "label": "3pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T16:00:03.000Z",
-    "Bikes in use": 246,
-    "Bikes available": 1131,
-    "label": "4pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T17:00:02.000Z",
-    "Bikes in use": 298,
-    "Bikes available": 1079,
-    "label": "5pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T18:00:02.000Z",
-    "Bikes in use": 120,
-    "Bikes available": 1257,
-    "label": "6pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T19:00:03.000Z",
-    "Bikes in use": 90,
-    "Bikes available": 1287,
-    "label": "7pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T20:00:02.000Z",
-    "Bikes in use": 49,
-    "Bikes available": 1328,
-    "label": "8pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T21:00:02.000Z",
-    "Bikes in use": 46,
-    "Bikes available": 1331,
-    "label": "9pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T22:00:03.000Z",
-    "Bikes in use": 4,
-    "Bikes available": 1373,
-    "label": "10pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-03T23:00:02.000Z",
-    "Bikes in use": 8,
-    "Bikes available": 1369,
-    "label": "11pm, Tuesday September 3rd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "12am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "1am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "2am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "3am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "4am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T05:00:03.000Z",
-    "Bikes in use": 13,
-    "Bikes available": 1364,
-    "label": "5am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T06:00:03.000Z",
-    "Bikes in use": 95,
-    "Bikes available": 1282,
-    "label": "6am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T07:00:02.000Z",
-    "Bikes in use": 299,
-    "Bikes available": 1078,
-    "label": "7am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T08:00:02.000Z",
-    "Bikes in use": 364,
-    "Bikes available": 1013,
-    "label": "8am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T09:00:02.000Z",
-    "Bikes in use": 160,
-    "Bikes available": 1217,
-    "label": "9am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T10:00:03.000Z",
-    "Bikes in use": 83,
-    "Bikes available": 1294,
-    "label": "10am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T11:00:02.000Z",
-    "Bikes in use": 85,
-    "Bikes available": 1292,
-    "label": "11am, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T12:00:03.000Z",
-    "Bikes in use": 225,
-    "Bikes available": 1152,
-    "label": "12pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T13:00:02.000Z",
-    "Bikes in use": 147,
-    "Bikes available": 1230,
-    "label": "1pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T14:00:02.000Z",
-    "Bikes in use": 90,
-    "Bikes available": 1287,
-    "label": "2pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T15:00:03.000Z",
-    "Bikes in use": 97,
-    "Bikes available": 1280,
-    "label": "3pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T16:00:02.000Z",
-    "Bikes in use": 185,
-    "Bikes available": 1192,
-    "label": "4pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T17:00:02.000Z",
-    "Bikes in use": 273,
-    "Bikes available": 1104,
-    "label": "5pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T18:00:03.000Z",
-    "Bikes in use": 143,
-    "Bikes available": 1234,
-    "label": "6pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T19:00:02.000Z",
-    "Bikes in use": 104,
-    "Bikes available": 1273,
-    "label": "7pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T20:00:02.000Z",
-    "Bikes in use": 74,
-    "Bikes available": 1303,
-    "label": "8pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T21:00:02.000Z",
-    "Bikes in use": 20,
-    "Bikes available": 1357,
-    "label": "9pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T22:00:02.000Z",
-    "Bikes in use": 2,
-    "Bikes available": 1375,
-    "label": "10pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-04T23:00:03.000Z",
-    "Bikes in use": 4,
-    "Bikes available": 1373,
-    "label": "11pm, Wednesday September 4th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "12am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1388,
-    "label": "1am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "2am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "3am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "4am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T05:00:03.000Z",
-    "Bikes in use": 12,
-    "Bikes available": 1365,
-    "label": "5am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T06:00:02.000Z",
-    "Bikes in use": 105,
-    "Bikes available": 1272,
-    "label": "6am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T07:00:02.000Z",
-    "Bikes in use": 275,
-    "Bikes available": 1102,
-    "label": "7am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T08:00:02.000Z",
-    "Bikes in use": 359,
-    "Bikes available": 1018,
-    "label": "8am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T09:00:02.000Z",
-    "Bikes in use": 149,
-    "Bikes available": 1228,
-    "label": "9am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T10:00:02.000Z",
-    "Bikes in use": 113,
-    "Bikes available": 1264,
-    "label": "10am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T11:00:03.000Z",
-    "Bikes in use": 75,
-    "Bikes available": 1302,
-    "label": "11am, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T12:00:03.000Z",
-    "Bikes in use": 170,
-    "Bikes available": 1207,
-    "label": "12pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T13:00:02.000Z",
-    "Bikes in use": 151,
-    "Bikes available": 1226,
-    "label": "1pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T14:00:02.000Z",
-    "Bikes in use": 75,
-    "Bikes available": 1302,
-    "label": "2pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T15:00:03.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1278,
-    "label": "3pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T16:00:03.000Z",
-    "Bikes in use": 241,
-    "Bikes available": 1136,
-    "label": "4pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T17:00:02.000Z",
-    "Bikes in use": 317,
-    "Bikes available": 1060,
-    "label": "5pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T18:00:03.000Z",
-    "Bikes in use": 188,
-    "Bikes available": 1189,
-    "label": "6pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T19:00:02.000Z",
-    "Bikes in use": 132,
-    "Bikes available": 1245,
-    "label": "7pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T20:00:03.000Z",
-    "Bikes in use": 55,
-    "Bikes available": 1322,
-    "label": "8pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T21:00:02.000Z",
-    "Bikes in use": 64,
-    "Bikes available": 1313,
-    "label": "9pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T22:00:02.000Z",
-    "Bikes in use": 21,
-    "Bikes available": 1356,
-    "label": "10pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-05T23:00:02.000Z",
-    "Bikes in use": 20,
-    "Bikes available": 1357,
-    "label": "11pm, Thursday September 5th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1383,
-    "label": "12am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1386,
-    "label": "1am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "2am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "3am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "4am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T05:00:03.000Z",
-    "Bikes in use": 6,
-    "Bikes available": 1371,
-    "label": "5am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T06:00:03.000Z",
-    "Bikes in use": 38,
-    "Bikes available": 1339,
-    "label": "6am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T07:00:03.000Z",
-    "Bikes in use": 215,
-    "Bikes available": 1162,
-    "label": "7am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T08:00:02.000Z",
-    "Bikes in use": 385,
-    "Bikes available": 992,
-    "label": "8am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T09:00:03.000Z",
-    "Bikes in use": 119,
-    "Bikes available": 1258,
-    "label": "9am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T10:00:02.000Z",
-    "Bikes in use": 87,
-    "Bikes available": 1290,
-    "label": "10am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T11:00:03.000Z",
-    "Bikes in use": 114,
-    "Bikes available": 1263,
-    "label": "11am, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T12:00:03.000Z",
-    "Bikes in use": 173,
-    "Bikes available": 1204,
-    "label": "12pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T13:00:03.000Z",
-    "Bikes in use": 142,
-    "Bikes available": 1235,
-    "label": "1pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T14:00:02.000Z",
-    "Bikes in use": 114,
-    "Bikes available": 1263,
-    "label": "2pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T15:00:03.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1278,
-    "label": "3pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T16:00:02.000Z",
-    "Bikes in use": 256,
-    "Bikes available": 1121,
-    "label": "4pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T17:00:02.000Z",
-    "Bikes in use": 239,
-    "Bikes available": 1138,
-    "label": "5pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T18:00:03.000Z",
-    "Bikes in use": 139,
-    "Bikes available": 1238,
-    "label": "6pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T19:00:03.000Z",
-    "Bikes in use": 65,
-    "Bikes available": 1312,
-    "label": "7pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T20:00:02.000Z",
-    "Bikes in use": 36,
-    "Bikes available": 1341,
-    "label": "8pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T21:00:03.000Z",
-    "Bikes in use": 12,
-    "Bikes available": 1365,
-    "label": "9pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T22:00:02.000Z",
-    "Bikes in use": 13,
-    "Bikes available": 1364,
-    "label": "10pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-06T23:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1384,
-    "label": "11pm, Friday September 6th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1403,
-    "label": "12am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "1am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1412,
-    "label": "2am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1412,
-    "label": "3am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1412,
-    "label": "4am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T05:00:27.000Z",
+    "date": "2019-09-26T01:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1410,
-    "label": "5am, Saturday September 7th",
+    "label": "9pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-09-07T06:00:03.000Z",
+    "date": "2019-09-26T02:30:02.000Z",
     "Bikes in use": 0,
-    "Bikes available": 1399,
-    "label": "6am, Saturday September 7th",
+    "Bikes available": 1410,
+    "label": "10pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-09-07T07:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1408,
-    "label": "7am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T08:00:02.000Z",
-    "Bikes in use": 7,
-    "Bikes available": 1370,
-    "label": "8am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T09:00:03.000Z",
-    "Bikes in use": 29,
-    "Bikes available": 1348,
-    "label": "9am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T10:00:03.000Z",
-    "Bikes in use": 47,
-    "Bikes available": 1330,
-    "label": "10am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T11:00:02.000Z",
-    "Bikes in use": 53,
-    "Bikes available": 1324,
-    "label": "11am, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T12:00:02.000Z",
-    "Bikes in use": 117,
-    "Bikes available": 1260,
-    "label": "12pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T13:00:03.000Z",
-    "Bikes in use": 70,
-    "Bikes available": 1307,
-    "label": "1pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T14:00:02.000Z",
-    "Bikes in use": 75,
-    "Bikes available": 1302,
-    "label": "2pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T15:00:02.000Z",
-    "Bikes in use": 89,
-    "Bikes available": 1288,
-    "label": "3pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T16:00:03.000Z",
-    "Bikes in use": 82,
-    "Bikes available": 1295,
-    "label": "4pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T17:00:03.000Z",
-    "Bikes in use": 82,
-    "Bikes available": 1295,
-    "label": "5pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T18:00:02.000Z",
-    "Bikes in use": 52,
-    "Bikes available": 1325,
-    "label": "6pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T19:00:02.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1343,
-    "label": "7pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T20:00:02.000Z",
-    "Bikes in use": 3,
-    "Bikes available": 1374,
-    "label": "8pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T21:00:02.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "9pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T22:00:03.000Z",
-    "Bikes in use": 4,
-    "Bikes available": 1373,
-    "label": "10pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-07T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1380,
-    "label": "11pm, Saturday September 7th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "12am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "1am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T02:00:02.000Z",
+    "date": "2019-09-26T03:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1411,
-    "label": "2am, Sunday September 8th",
+    "label": "11pm, Wednesday September 25th",
     "year": "2019"
   },
   {
-    "date": "2019-09-08T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1411,
-    "label": "3am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1412,
-    "label": "4am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "5am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T06:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "6am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T07:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "7am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T08:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "8am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T09:00:02.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1367,
-    "label": "9am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T10:00:03.000Z",
-    "Bikes in use": 38,
-    "Bikes available": 1339,
-    "label": "10am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T11:00:02.000Z",
-    "Bikes in use": 53,
-    "Bikes available": 1324,
-    "label": "11am, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T12:00:02.000Z",
-    "Bikes in use": 81,
-    "Bikes available": 1296,
-    "label": "12pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T13:00:03.000Z",
-    "Bikes in use": 110,
-    "Bikes available": 1267,
-    "label": "1pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T14:00:02.000Z",
-    "Bikes in use": 111,
-    "Bikes available": 1266,
-    "label": "2pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T15:00:03.000Z",
-    "Bikes in use": 106,
-    "Bikes available": 1271,
-    "label": "3pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T16:00:02.000Z",
-    "Bikes in use": 66,
-    "Bikes available": 1311,
-    "label": "4pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T17:00:02.000Z",
-    "Bikes in use": 71,
-    "Bikes available": 1306,
-    "label": "5pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T18:00:02.000Z",
-    "Bikes in use": 66,
-    "Bikes available": 1311,
-    "label": "6pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T19:00:03.000Z",
-    "Bikes in use": 25,
-    "Bikes available": 1352,
-    "label": "7pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T20:00:03.000Z",
-    "Bikes in use": 9,
-    "Bikes available": 1368,
-    "label": "8pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T21:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1392,
-    "label": "9pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1401,
-    "label": "10pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-08T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1393,
-    "label": "11pm, Sunday September 8th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1406,
-    "label": "12am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "1am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "2am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "3am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "4am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T05:00:02.000Z",
-    "Bikes in use": 13,
-    "Bikes available": 1364,
-    "label": "5am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T06:00:03.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1343,
-    "label": "6am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T07:00:02.000Z",
-    "Bikes in use": 186,
-    "Bikes available": 1191,
-    "label": "7am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T08:00:03.000Z",
-    "Bikes in use": 345,
-    "Bikes available": 1032,
-    "label": "8am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T09:00:02.000Z",
-    "Bikes in use": 128,
-    "Bikes available": 1249,
-    "label": "9am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T10:00:02.000Z",
-    "Bikes in use": 136,
-    "Bikes available": 1241,
-    "label": "10am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T11:00:02.000Z",
-    "Bikes in use": 148,
-    "Bikes available": 1229,
-    "label": "11am, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T12:00:28.000Z",
-    "Bikes in use": 194,
-    "Bikes available": 1183,
-    "label": "12pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T13:00:02.000Z",
-    "Bikes in use": 142,
-    "Bikes available": 1235,
-    "label": "1pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T14:00:02.000Z",
-    "Bikes in use": 84,
-    "Bikes available": 1293,
-    "label": "2pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T15:00:02.000Z",
-    "Bikes in use": 86,
-    "Bikes available": 1291,
-    "label": "3pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T16:00:02.000Z",
-    "Bikes in use": 227,
-    "Bikes available": 1150,
-    "label": "4pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T17:00:02.000Z",
-    "Bikes in use": 306,
-    "Bikes available": 1071,
-    "label": "5pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T18:00:03.000Z",
-    "Bikes in use": 216,
-    "Bikes available": 1161,
-    "label": "6pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T19:00:03.000Z",
-    "Bikes in use": 126,
-    "Bikes available": 1251,
-    "label": "7pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T20:00:03.000Z",
-    "Bikes in use": 42,
-    "Bikes available": 1335,
-    "label": "8pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T21:00:03.000Z",
-    "Bikes in use": 21,
-    "Bikes available": 1356,
-    "label": "9pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T22:00:03.000Z",
-    "Bikes in use": 1,
-    "Bikes available": 1376,
-    "label": "10pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-09T23:00:03.000Z",
-    "Bikes in use": 11,
-    "Bikes available": 1366,
-    "label": "11pm, Monday September 9th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "12am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "1am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "2am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "3am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "4am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T05:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1386,
-    "label": "5am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T06:00:03.000Z",
-    "Bikes in use": 58,
-    "Bikes available": 1319,
-    "label": "6am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T07:00:02.000Z",
-    "Bikes in use": 254,
-    "Bikes available": 1123,
-    "label": "7am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T08:00:03.000Z",
-    "Bikes in use": 397,
-    "Bikes available": 980,
-    "label": "8am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T09:00:03.000Z",
-    "Bikes in use": 123,
-    "Bikes available": 1254,
-    "label": "9am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T10:00:03.000Z",
-    "Bikes in use": 134,
-    "Bikes available": 1243,
-    "label": "10am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T11:00:02.000Z",
-    "Bikes in use": 142,
-    "Bikes available": 1235,
-    "label": "11am, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T12:00:02.000Z",
-    "Bikes in use": 258,
-    "Bikes available": 1119,
-    "label": "12pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T13:00:02.000Z",
-    "Bikes in use": 179,
-    "Bikes available": 1198,
-    "label": "1pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T14:00:02.000Z",
-    "Bikes in use": 107,
-    "Bikes available": 1270,
-    "label": "2pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T15:00:02.000Z",
-    "Bikes in use": 100,
-    "Bikes available": 1277,
-    "label": "3pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T16:00:03.000Z",
-    "Bikes in use": 266,
-    "Bikes available": 1111,
-    "label": "4pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T17:00:02.000Z",
-    "Bikes in use": 276,
-    "Bikes available": 1101,
-    "label": "5pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T18:00:02.000Z",
-    "Bikes in use": 174,
-    "Bikes available": 1203,
-    "label": "6pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T19:00:02.000Z",
-    "Bikes in use": 136,
-    "Bikes available": 1241,
-    "label": "7pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T20:00:02.000Z",
-    "Bikes in use": 55,
-    "Bikes available": 1322,
-    "label": "8pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T21:00:03.000Z",
-    "Bikes in use": 58,
-    "Bikes available": 1319,
-    "label": "9pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T22:00:03.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1367,
-    "label": "10pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-10T23:00:02.000Z",
-    "Bikes in use": 5,
-    "Bikes available": 1372,
-    "label": "11pm, Tuesday September 10th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T00:00:03.000Z",
-    "Bikes in use": 2,
-    "Bikes available": 1375,
-    "label": "12am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T01:00:03.000Z",
-    "Bikes in use": 1,
-    "Bikes available": 1376,
-    "label": "1am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "2am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "3am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "4am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T05:00:02.000Z",
-    "Bikes in use": 15,
-    "Bikes available": 1362,
-    "label": "5am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T06:00:02.000Z",
-    "Bikes in use": 112,
-    "Bikes available": 1265,
-    "label": "6am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T07:00:02.000Z",
-    "Bikes in use": 305,
-    "Bikes available": 1072,
-    "label": "7am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T08:00:02.000Z",
-    "Bikes in use": 397,
-    "Bikes available": 980,
-    "label": "8am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T09:00:03.000Z",
-    "Bikes in use": 152,
-    "Bikes available": 1225,
-    "label": "9am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T10:00:03.000Z",
-    "Bikes in use": 133,
-    "Bikes available": 1244,
-    "label": "10am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T11:00:02.000Z",
-    "Bikes in use": 141,
-    "Bikes available": 1236,
-    "label": "11am, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T12:00:02.000Z",
-    "Bikes in use": 248,
-    "Bikes available": 1129,
-    "label": "12pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T13:00:02.000Z",
-    "Bikes in use": 165,
-    "Bikes available": 1212,
-    "label": "1pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T14:00:03.000Z",
-    "Bikes in use": 88,
-    "Bikes available": 1289,
-    "label": "2pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T15:00:03.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1278,
-    "label": "3pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T16:00:03.000Z",
-    "Bikes in use": 254,
-    "Bikes available": 1123,
-    "label": "4pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T17:00:02.000Z",
-    "Bikes in use": 295,
-    "Bikes available": 1082,
-    "label": "5pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T18:00:02.000Z",
-    "Bikes in use": 137,
-    "Bikes available": 1240,
-    "label": "6pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T19:00:02.000Z",
-    "Bikes in use": 85,
-    "Bikes available": 1292,
-    "label": "7pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T20:00:03.000Z",
-    "Bikes in use": 32,
-    "Bikes available": 1345,
-    "label": "8pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T21:00:03.000Z",
-    "Bikes in use": 54,
-    "Bikes available": 1323,
-    "label": "9pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1379,
-    "label": "10pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-11T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "11pm, Wednesday September 11th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1381,
-    "label": "1am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1415,
-    "label": "2am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1417,
-    "label": "3am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1421,
-    "label": "4am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1382,
-    "label": "5am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T06:00:02.000Z",
-    "Bikes in use": 67,
-    "Bikes available": 1310,
-    "label": "6am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T07:00:02.000Z",
-    "Bikes in use": 190,
-    "Bikes available": 1187,
-    "label": "7am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T08:00:03.000Z",
-    "Bikes in use": 359,
-    "Bikes available": 1018,
-    "label": "8am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T09:00:02.000Z",
-    "Bikes in use": 117,
-    "Bikes available": 1260,
-    "label": "9am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T10:00:03.000Z",
-    "Bikes in use": 43,
-    "Bikes available": 1334,
-    "label": "10am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T11:00:02.000Z",
-    "Bikes in use": 107,
-    "Bikes available": 1270,
-    "label": "11am, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T12:00:03.000Z",
-    "Bikes in use": 200,
-    "Bikes available": 1177,
-    "label": "12pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T13:00:03.000Z",
-    "Bikes in use": 164,
-    "Bikes available": 1213,
-    "label": "1pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T14:00:02.000Z",
-    "Bikes in use": 64,
-    "Bikes available": 1313,
-    "label": "2pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T15:00:02.000Z",
-    "Bikes in use": 69,
-    "Bikes available": 1308,
-    "label": "3pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T16:00:02.000Z",
-    "Bikes in use": 216,
-    "Bikes available": 1161,
-    "label": "4pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T17:00:02.000Z",
-    "Bikes in use": 281,
-    "Bikes available": 1096,
-    "label": "5pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T18:00:02.000Z",
-    "Bikes in use": 126,
-    "Bikes available": 1251,
-    "label": "6pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T19:00:02.000Z",
-    "Bikes in use": 89,
-    "Bikes available": 1288,
-    "label": "7pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T20:00:03.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1343,
-    "label": "8pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T21:00:02.000Z",
-    "Bikes in use": 55,
-    "Bikes available": 1322,
-    "label": "9pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T22:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1391,
-    "label": "10pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-12T23:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1389,
-    "label": "11pm, Thursday September 12th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1406,
-    "label": "12am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "1am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "2am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "3am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "4am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1393,
-    "label": "5am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T06:00:02.000Z",
-    "Bikes in use": 38,
-    "Bikes available": 1339,
-    "label": "6am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T07:00:03.000Z",
-    "Bikes in use": 211,
-    "Bikes available": 1166,
-    "label": "7am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T08:00:02.000Z",
-    "Bikes in use": 346,
-    "Bikes available": 1031,
-    "label": "8am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T09:00:02.000Z",
-    "Bikes in use": 138,
-    "Bikes available": 1239,
-    "label": "9am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T10:00:02.000Z",
-    "Bikes in use": 73,
-    "Bikes available": 1304,
-    "label": "10am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T11:00:02.000Z",
-    "Bikes in use": 98,
-    "Bikes available": 1279,
-    "label": "11am, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T12:00:02.000Z",
-    "Bikes in use": 168,
-    "Bikes available": 1209,
-    "label": "12pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T13:00:03.000Z",
-    "Bikes in use": 133,
-    "Bikes available": 1244,
-    "label": "1pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T14:00:03.000Z",
-    "Bikes in use": 78,
-    "Bikes available": 1299,
-    "label": "2pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T15:00:02.000Z",
-    "Bikes in use": 141,
-    "Bikes available": 1236,
-    "label": "3pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T16:00:02.000Z",
-    "Bikes in use": 219,
-    "Bikes available": 1158,
-    "label": "4pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T17:00:03.000Z",
-    "Bikes in use": 238,
-    "Bikes available": 1139,
-    "label": "5pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T18:00:02.000Z",
-    "Bikes in use": 121,
-    "Bikes available": 1256,
-    "label": "6pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T19:00:02.000Z",
-    "Bikes in use": 78,
-    "Bikes available": 1299,
-    "label": "7pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T20:00:02.000Z",
-    "Bikes in use": 20,
-    "Bikes available": 1357,
-    "label": "8pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T21:00:02.000Z",
-    "Bikes in use": 12,
-    "Bikes available": 1365,
-    "label": "9pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "10pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-13T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1389,
-    "label": "11pm, Friday September 13th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1429,
-    "label": "12am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1433,
-    "label": "1am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1436,
-    "label": "2am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1438,
-    "label": "3am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1438,
-    "label": "4am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1430,
-    "label": "5am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T06:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1427,
-    "label": "6am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T07:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1426,
-    "label": "7am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T08:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1393,
-    "label": "8am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T09:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1387,
-    "label": "9am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T10:00:02.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1343,
-    "label": "10am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T11:00:03.000Z",
-    "Bikes in use": 64,
-    "Bikes available": 1313,
-    "label": "11am, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T12:00:03.000Z",
-    "Bikes in use": 52,
-    "Bikes available": 1325,
-    "label": "12pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T13:00:02.000Z",
-    "Bikes in use": 67,
-    "Bikes available": 1310,
-    "label": "1pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T14:00:03.000Z",
-    "Bikes in use": 98,
-    "Bikes available": 1279,
-    "label": "2pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T15:00:02.000Z",
-    "Bikes in use": 118,
-    "Bikes available": 1259,
-    "label": "3pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T16:00:02.000Z",
-    "Bikes in use": 135,
-    "Bikes available": 1242,
-    "label": "4pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T17:00:02.000Z",
-    "Bikes in use": 81,
-    "Bikes available": 1296,
-    "label": "5pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T18:00:02.000Z",
-    "Bikes in use": 40,
-    "Bikes available": 1337,
-    "label": "6pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T19:00:03.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1343,
-    "label": "7pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T20:00:27.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "8pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T21:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1399,
-    "label": "9pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1394,
-    "label": "10pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-14T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1417,
-    "label": "11pm, Saturday September 14th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1437,
-    "label": "12am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1442,
-    "label": "1am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "2am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1445,
-    "label": "3am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1445,
-    "label": "4am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T05:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1446,
-    "label": "5am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T06:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1438,
-    "label": "6am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T07:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1435,
-    "label": "7am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T08:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1413,
-    "label": "8am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T09:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1416,
-    "label": "9am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T10:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "10am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T11:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1379,
-    "label": "11am, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T12:00:03.000Z",
-    "Bikes in use": 9,
-    "Bikes available": 1368,
-    "label": "12pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T13:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1385,
-    "label": "1pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T14:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1378,
-    "label": "2pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T15:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1381,
-    "label": "3pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T16:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1415,
-    "label": "4pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T17:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1415,
-    "label": "5pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T18:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1416,
-    "label": "6pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T19:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1429,
-    "label": "7pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T20:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1428,
-    "label": "8pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T21:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1442,
-    "label": "9pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "10pm, Sunday September 15th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-15T23:00:02.000Z",
+    "date": "2019-09-26T04:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1440,
-    "label": "11pm, Sunday September 15th",
+    "label": "12am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T00:00:03.000Z",
+    "date": "2019-09-26T05:30:02.000Z",
     "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "12am, Monday September 16th",
+    "Bikes available": 1402,
+    "label": "1am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "1am, Monday September 16th",
+    "date": "2019-09-26T06:30:02.000Z",
+    "Bikes in use": 73,
+    "Bikes available": 1304,
+    "label": "2am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "2am, Monday September 16th",
+    "date": "2019-09-26T07:30:02.000Z",
+    "Bikes in use": 358,
+    "Bikes available": 1019,
+    "label": "3am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "3am, Monday September 16th",
+    "date": "2019-09-26T08:30:02.000Z",
+    "Bikes in use": 143,
+    "Bikes available": 1234,
+    "label": "4am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "4am, Monday September 16th",
+    "date": "2019-09-26T09:30:02.000Z",
+    "Bikes in use": 84,
+    "Bikes available": 1293,
+    "label": "5am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1429,
-    "label": "5am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T06:00:02.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1358,
-    "label": "6am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T07:00:02.000Z",
-    "Bikes in use": 163,
-    "Bikes available": 1214,
-    "label": "7am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T08:00:02.000Z",
-    "Bikes in use": 252,
-    "Bikes available": 1125,
-    "label": "8am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T09:00:02.000Z",
-    "Bikes in use": 90,
-    "Bikes available": 1287,
-    "label": "9am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T10:00:02.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1278,
-    "label": "10am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T11:00:02.000Z",
-    "Bikes in use": 60,
-    "Bikes available": 1317,
-    "label": "11am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T12:00:02.000Z",
-    "Bikes in use": 111,
-    "Bikes available": 1266,
-    "label": "12pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T13:00:02.000Z",
-    "Bikes in use": 96,
-    "Bikes available": 1281,
-    "label": "1pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T14:00:03.000Z",
-    "Bikes in use": 43,
-    "Bikes available": 1334,
-    "label": "2pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T15:00:03.000Z",
-    "Bikes in use": 32,
-    "Bikes available": 1345,
-    "label": "3pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T16:00:03.000Z",
-    "Bikes in use": 211,
-    "Bikes available": 1166,
-    "label": "4pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T17:00:02.000Z",
-    "Bikes in use": 287,
-    "Bikes available": 1090,
-    "label": "5pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T18:00:02.000Z",
-    "Bikes in use": 146,
-    "Bikes available": 1231,
-    "label": "6pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T19:00:03.000Z",
-    "Bikes in use": 108,
-    "Bikes available": 1269,
-    "label": "7pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T20:00:02.000Z",
-    "Bikes in use": 37,
-    "Bikes available": 1340,
-    "label": "8pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T21:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1390,
-    "label": "9pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1383,
-    "label": "10pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T23:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1399,
-    "label": "11pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1411,
-    "label": "12am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1413,
-    "label": "1am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1413,
-    "label": "2am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1414,
-    "label": "3am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1414,
-    "label": "4am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T05:00:02.000Z",
-    "Bikes in use": 8,
-    "Bikes available": 1369,
-    "label": "5am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T06:00:02.000Z",
-    "Bikes in use": 32,
-    "Bikes available": 1345,
-    "label": "6am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T07:00:03.000Z",
-    "Bikes in use": 230,
-    "Bikes available": 1147,
-    "label": "7am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T08:00:02.000Z",
-    "Bikes in use": 328,
-    "Bikes available": 1049,
-    "label": "8am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T09:00:02.000Z",
-    "Bikes in use": 89,
-    "Bikes available": 1288,
-    "label": "9am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T10:00:02.000Z",
-    "Bikes in use": 50,
-    "Bikes available": 1327,
-    "label": "10am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T11:00:02.000Z",
-    "Bikes in use": 58,
-    "Bikes available": 1319,
-    "label": "11am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T12:00:02.000Z",
-    "Bikes in use": 153,
-    "Bikes available": 1224,
-    "label": "12pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T13:00:03.000Z",
-    "Bikes in use": 137,
-    "Bikes available": 1240,
-    "label": "1pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T14:00:03.000Z",
-    "Bikes in use": 47,
-    "Bikes available": 1330,
-    "label": "2pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T15:00:03.000Z",
-    "Bikes in use": 72,
-    "Bikes available": 1305,
-    "label": "3pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T17:00:02.000Z",
-    "Bikes in use": 310,
-    "Bikes available": 1067,
-    "label": "5pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T18:00:03.000Z",
-    "Bikes in use": 159,
-    "Bikes available": 1218,
-    "label": "6pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T19:00:03.000Z",
+    "date": "2019-09-26T10:30:02.000Z",
     "Bikes in use": 88,
     "Bikes available": 1289,
-    "label": "7pm, Tuesday September 17th",
+    "label": "6am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-17T20:00:03.000Z",
-    "Bikes in use": 32,
-    "Bikes available": 1345,
-    "label": "8pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T21:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "9pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T22:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1397,
-    "label": "10pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1397,
-    "label": "11pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T00:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1408,
-    "label": "12am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1410,
-    "label": "1am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1410,
-    "label": "2am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1410,
-    "label": "3am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1410,
-    "label": "4am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1408,
-    "label": "5am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T06:00:02.000Z",
-    "Bikes in use": 53,
-    "Bikes available": 1324,
-    "label": "6am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T07:00:02.000Z",
-    "Bikes in use": 262,
-    "Bikes available": 1115,
-    "label": "7am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T08:00:02.000Z",
-    "Bikes in use": 374,
-    "Bikes available": 1003,
-    "label": "8am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T09:00:02.000Z",
-    "Bikes in use": 148,
-    "Bikes available": 1229,
-    "label": "9am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T10:00:02.000Z",
-    "Bikes in use": 124,
-    "Bikes available": 1253,
-    "label": "10am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T11:00:03.000Z",
-    "Bikes in use": 77,
-    "Bikes available": 1300,
-    "label": "11am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T12:00:02.000Z",
-    "Bikes in use": 192,
-    "Bikes available": 1185,
-    "label": "12pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T13:00:03.000Z",
+    "date": "2019-09-26T11:30:02.000Z",
     "Bikes in use": 144,
     "Bikes available": 1233,
-    "label": "1pm, Wednesday September 18th",
+    "label": "7am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T14:00:02.000Z",
-    "Bikes in use": 93,
-    "Bikes available": 1284,
-    "label": "2pm, Wednesday September 18th",
+    "date": "2019-09-26T12:30:02.000Z",
+    "Bikes in use": 171,
+    "Bikes available": 1206,
+    "label": "8am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T15:00:02.000Z",
-    "Bikes in use": 105,
-    "Bikes available": 1272,
-    "label": "3pm, Wednesday September 18th",
+    "date": "2019-09-26T13:30:02.000Z",
+    "Bikes in use": 59,
+    "Bikes available": 1318,
+    "label": "9am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T16:00:02.000Z",
-    "Bikes in use": 288,
-    "Bikes available": 1089,
-    "label": "4pm, Wednesday September 18th",
+    "date": "2019-09-26T14:30:27.000Z",
+    "Bikes in use": 63,
+    "Bikes available": 1314,
+    "label": "10am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T17:00:03.000Z",
-    "Bikes in use": 324,
-    "Bikes available": 1053,
-    "label": "5pm, Wednesday September 18th",
+    "date": "2019-09-26T15:30:02.000Z",
+    "Bikes in use": 159,
+    "Bikes available": 1218,
+    "label": "11am, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T18:00:03.000Z",
-    "Bikes in use": 204,
-    "Bikes available": 1173,
-    "label": "6pm, Wednesday September 18th",
+    "date": "2019-09-26T16:30:02.000Z",
+    "Bikes in use": 273,
+    "Bikes available": 1104,
+    "label": "12pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T19:00:03.000Z",
-    "Bikes in use": 138,
-    "Bikes available": 1239,
-    "label": "7pm, Wednesday September 18th",
+    "date": "2019-09-26T17:30:03.000Z",
+    "Bikes in use": 117,
+    "Bikes available": 1260,
+    "label": "1pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T20:00:02.000Z",
-    "Bikes in use": 61,
-    "Bikes available": 1316,
-    "label": "8pm, Wednesday September 18th",
+    "date": "2019-09-26T18:30:02.000Z",
+    "Bikes in use": 88,
+    "Bikes available": 1289,
+    "label": "2pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-18T21:00:03.000Z",
-    "Bikes in use": 43,
-    "Bikes available": 1334,
-    "label": "9pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T22:00:03.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1367,
-    "label": "10pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1384,
-    "label": "11pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "12am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "1am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T02:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "2am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T03:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "3am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1402,
-    "label": "4am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T05:00:02.000Z",
-    "Bikes in use": 12,
-    "Bikes available": 1365,
-    "label": "5am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T06:00:02.000Z",
-    "Bikes in use": 89,
-    "Bikes available": 1288,
-    "label": "6am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T07:00:03.000Z",
-    "Bikes in use": 229,
-    "Bikes available": 1148,
-    "label": "7am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T08:00:02.000Z",
-    "Bikes in use": 415,
-    "Bikes available": 962,
-    "label": "8am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T09:00:02.000Z",
-    "Bikes in use": 131,
-    "Bikes available": 1246,
-    "label": "9am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T10:00:02.000Z",
-    "Bikes in use": 121,
-    "Bikes available": 1256,
-    "label": "10am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T11:00:02.000Z",
-    "Bikes in use": 90,
-    "Bikes available": 1287,
-    "label": "11am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T12:00:03.000Z",
-    "Bikes in use": 213,
-    "Bikes available": 1164,
-    "label": "12pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T13:00:02.000Z",
-    "Bikes in use": 167,
-    "Bikes available": 1210,
-    "label": "1pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T14:00:02.000Z",
-    "Bikes in use": 51,
-    "Bikes available": 1326,
-    "label": "2pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T15:00:02.000Z",
-    "Bikes in use": 66,
-    "Bikes available": 1311,
-    "label": "3pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T16:00:02.000Z",
-    "Bikes in use": 265,
-    "Bikes available": 1112,
-    "label": "4pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T17:00:03.000Z",
-    "Bikes in use": 333,
-    "Bikes available": 1044,
-    "label": "5pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T18:00:02.000Z",
-    "Bikes in use": 162,
-    "Bikes available": 1215,
-    "label": "6pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T19:00:02.000Z",
-    "Bikes in use": 66,
-    "Bikes available": 1311,
-    "label": "7pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T20:00:02.000Z",
-    "Bikes in use": 20,
-    "Bikes available": 1357,
-    "label": "8pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T21:00:03.000Z",
-    "Bikes in use": 9,
-    "Bikes available": 1368,
-    "label": "9pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T22:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1413,
-    "label": "10pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1414,
-    "label": "11pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1423,
-    "label": "12am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1424,
-    "label": "1am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1424,
-    "label": "2am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1425,
-    "label": "3am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1426,
-    "label": "4am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1391,
-    "label": "5am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T06:00:02.000Z",
-    "Bikes in use": 44,
-    "Bikes available": 1333,
-    "label": "6am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T07:00:02.000Z",
-    "Bikes in use": 224,
-    "Bikes available": 1153,
-    "label": "7am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T08:00:03.000Z",
-    "Bikes in use": 327,
-    "Bikes available": 1050,
-    "label": "8am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T09:00:02.000Z",
-    "Bikes in use": 132,
-    "Bikes available": 1245,
-    "label": "9am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T10:00:02.000Z",
-    "Bikes in use": 60,
-    "Bikes available": 1317,
-    "label": "10am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T11:00:03.000Z",
-    "Bikes in use": 94,
-    "Bikes available": 1283,
-    "label": "11am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T12:00:02.000Z",
-    "Bikes in use": 209,
-    "Bikes available": 1168,
-    "label": "12pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T13:00:02.000Z",
-    "Bikes in use": 166,
-    "Bikes available": 1211,
-    "label": "1pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T14:00:02.000Z",
-    "Bikes in use": 71,
-    "Bikes available": 1306,
-    "label": "2pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T15:00:02.000Z",
-    "Bikes in use": 174,
-    "Bikes available": 1203,
-    "label": "3pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T16:00:02.000Z",
-    "Bikes in use": 287,
-    "Bikes available": 1090,
-    "label": "4pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T17:00:02.000Z",
-    "Bikes in use": 287,
-    "Bikes available": 1090,
-    "label": "5pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T18:00:03.000Z",
-    "Bikes in use": 147,
-    "Bikes available": 1230,
-    "label": "6pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T19:00:02.000Z",
-    "Bikes in use": 96,
-    "Bikes available": 1281,
-    "label": "7pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T20:00:03.000Z",
-    "Bikes in use": 46,
-    "Bikes available": 1331,
-    "label": "8pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T21:00:02.000Z",
-    "Bikes in use": 58,
-    "Bikes available": 1319,
-    "label": "9pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T22:00:02.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1358,
-    "label": "10pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T23:00:02.000Z",
-    "Bikes in use": 1,
-    "Bikes available": 1376,
-    "label": "11pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1419,
-    "label": "12am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T01:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1425,
-    "label": "1am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1425,
-    "label": "2am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1425,
-    "label": "3am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1425,
-    "label": "4am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1416,
-    "label": "5am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T06:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1411,
-    "label": "6am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T07:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1410,
-    "label": "7am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T08:00:03.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1367,
-    "label": "8am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T09:00:02.000Z",
-    "Bikes in use": 39,
-    "Bikes available": 1338,
-    "label": "9am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T10:00:02.000Z",
-    "Bikes in use": 87,
-    "Bikes available": 1290,
-    "label": "10am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T11:00:02.000Z",
-    "Bikes in use": 108,
-    "Bikes available": 1269,
-    "label": "11am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T12:00:02.000Z",
-    "Bikes in use": 153,
-    "Bikes available": 1224,
-    "label": "12pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T13:00:03.000Z",
-    "Bikes in use": 118,
-    "Bikes available": 1259,
-    "label": "1pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T14:00:02.000Z",
-    "Bikes in use": 121,
-    "Bikes available": 1256,
-    "label": "2pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T15:00:03.000Z",
-    "Bikes in use": 118,
-    "Bikes available": 1259,
-    "label": "3pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T16:00:02.000Z",
-    "Bikes in use": 107,
-    "Bikes available": 1270,
-    "label": "4pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T17:00:02.000Z",
-    "Bikes in use": 65,
-    "Bikes available": 1312,
-    "label": "5pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T18:00:03.000Z",
-    "Bikes in use": 8,
-    "Bikes available": 1369,
-    "label": "6pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T19:00:28.000Z",
-    "Bikes in use": 14,
-    "Bikes available": 1363,
-    "label": "7pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T20:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1379,
-    "label": "8pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T21:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1386,
-    "label": "9pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T22:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1387,
-    "label": "10pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T23:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1377,
-    "label": "11pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T00:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1405,
-    "label": "12am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T01:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1414,
-    "label": "1am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T02:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1418,
-    "label": "2am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1419,
-    "label": "3am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T04:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1419,
-    "label": "4am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T05:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1415,
-    "label": "5am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T06:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1418,
-    "label": "6am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T07:00:02.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1415,
-    "label": "7am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T08:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1407,
-    "label": "8am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T09:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1400,
-    "label": "9am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T10:00:03.000Z",
-    "Bikes in use": 10,
-    "Bikes available": 1367,
-    "label": "10am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T11:00:03.000Z",
-    "Bikes in use": 21,
-    "Bikes available": 1356,
-    "label": "11am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T12:00:03.000Z",
-    "Bikes in use": 35,
-    "Bikes available": 1342,
-    "label": "12pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T13:00:03.000Z",
-    "Bikes in use": 56,
-    "Bikes available": 1321,
-    "label": "1pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T14:00:02.000Z",
-    "Bikes in use": 44,
-    "Bikes available": 1333,
-    "label": "2pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T15:00:02.000Z",
-    "Bikes in use": 69,
-    "Bikes available": 1308,
-    "label": "3pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T16:00:02.000Z",
+    "date": "2019-09-26T19:30:02.000Z",
     "Bikes in use": 52,
     "Bikes available": 1325,
-    "label": "4pm, Sunday September 22nd",
+    "label": "3pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T17:00:02.000Z",
-    "Bikes in use": 56,
-    "Bikes available": 1321,
-    "label": "5pm, Sunday September 22nd",
+    "date": "2019-09-26T20:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "4pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T18:00:03.000Z",
-    "Bikes in use": 13,
-    "Bikes available": 1364,
-    "label": "6pm, Sunday September 22nd",
+    "date": "2019-09-26T21:30:03.000Z",
+    "Bikes in use": 37,
+    "Bikes available": 1340,
+    "label": "5pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T19:00:02.000Z",
+    "date": "2019-09-26T22:30:03.000Z",
     "Bikes in use": 0,
-    "Bikes available": 1409,
-    "label": "7pm, Sunday September 22nd",
+    "Bikes available": 1380,
+    "label": "6pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T20:00:02.000Z",
+    "date": "2019-09-26T23:30:02.000Z",
     "Bikes in use": 0,
-    "Bikes available": 1398,
-    "label": "8pm, Sunday September 22nd",
+    "Bikes available": 1378,
+    "label": "7pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T21:00:03.000Z",
+    "date": "2019-09-27T00:30:03.000Z",
     "Bikes in use": 0,
-    "Bikes available": 1396,
-    "label": "9pm, Sunday September 22nd",
+    "Bikes available": 1384,
+    "label": "8pm, Thursday September 26th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T22:00:03.000Z",
+    "date": "2019-09-27T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1384,
+    "label": "9pm, Thursday September 26th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1384,
+    "label": "10pm, Thursday September 26th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1384,
+    "label": "11pm, Thursday September 26th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1390,
+    "label": "12am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T05:30:02.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "1am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T06:30:03.000Z",
+    "Bikes in use": 102,
+    "Bikes available": 1275,
+    "label": "2am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T07:30:03.000Z",
+    "Bikes in use": 233,
+    "Bikes available": 1144,
+    "label": "3am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T08:30:02.000Z",
+    "Bikes in use": 124,
+    "Bikes available": 1253,
+    "label": "4am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T09:30:02.000Z",
+    "Bikes in use": 33,
+    "Bikes available": 1344,
+    "label": "5am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T10:30:02.000Z",
+    "Bikes in use": 33,
+    "Bikes available": 1344,
+    "label": "6am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T11:30:02.000Z",
+    "Bikes in use": 151,
+    "Bikes available": 1226,
+    "label": "7am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T12:30:02.000Z",
+    "Bikes in use": 161,
+    "Bikes available": 1216,
+    "label": "8am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T13:30:02.000Z",
+    "Bikes in use": 53,
+    "Bikes available": 1324,
+    "label": "9am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T14:30:02.000Z",
+    "Bikes in use": 57,
+    "Bikes available": 1320,
+    "label": "10am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T15:30:02.000Z",
+    "Bikes in use": 130,
+    "Bikes available": 1247,
+    "label": "11am, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T16:30:02.000Z",
+    "Bikes in use": 297,
+    "Bikes available": 1080,
+    "label": "12pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T17:30:02.000Z",
+    "Bikes in use": 177,
+    "Bikes available": 1200,
+    "label": "1pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T18:30:02.000Z",
+    "Bikes in use": 80,
+    "Bikes available": 1297,
+    "label": "2pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T19:30:03.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "3pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T20:30:02.000Z",
+    "Bikes in use": 6,
+    "Bikes available": 1371,
+    "label": "4pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T21:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1387,
+    "label": "5pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-27T22:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1410,
-    "label": "10pm, Sunday September 22nd",
+    "label": "6pm, Friday September 27th",
     "year": "2019"
   },
   {
-    "date": "2019-09-22T23:00:02.000Z",
+    "date": "2019-09-27T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1394,
+    "label": "7pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1429,
+    "label": "8pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1430,
+    "label": "9pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1431,
+    "label": "10pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T03:30:27.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1431,
+    "label": "11pm, Friday September 27th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1421,
+    "label": "12am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T05:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1418,
+    "label": "1am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T06:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1402,
-    "label": "11pm, Sunday September 22nd",
+    "label": "2am, Saturday September 28th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T00:00:03.000Z",
+    "date": "2019-09-28T07:30:02.000Z",
+    "Bikes in use": 9,
+    "Bikes available": 1368,
+    "label": "3am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T08:30:02.000Z",
+    "Bikes in use": 6,
+    "Bikes available": 1371,
+    "label": "4am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T09:30:03.000Z",
+    "Bikes in use": 41,
+    "Bikes available": 1336,
+    "label": "5am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T10:30:02.000Z",
+    "Bikes in use": 59,
+    "Bikes available": 1318,
+    "label": "6am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T11:30:02.000Z",
+    "Bikes in use": 72,
+    "Bikes available": 1305,
+    "label": "7am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T12:30:03.000Z",
+    "Bikes in use": 69,
+    "Bikes available": 1308,
+    "label": "8am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T13:30:03.000Z",
+    "Bikes in use": 85,
+    "Bikes available": 1292,
+    "label": "9am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T14:30:02.000Z",
+    "Bikes in use": 78,
+    "Bikes available": 1299,
+    "label": "10am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T15:30:02.000Z",
+    "Bikes in use": 59,
+    "Bikes available": 1318,
+    "label": "11am, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T16:30:27.000Z",
+    "Bikes in use": 53,
+    "Bikes available": 1324,
+    "label": "12pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T17:30:02.000Z",
+    "Bikes in use": 36,
+    "Bikes available": 1341,
+    "label": "1pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T18:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1378,
+    "label": "2pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T19:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1404,
+    "label": "3pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T20:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1400,
+    "label": "4pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T21:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1412,
-    "label": "12am, Monday September 23rd",
+    "label": "5pm, Saturday September 28th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T01:00:03.000Z",
+    "date": "2019-09-28T22:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1413,
+    "label": "6pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-28T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1405,
+    "label": "7pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1420,
+    "label": "8pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1421,
+    "label": "9pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1422,
+    "label": "10pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1422,
+    "label": "11pm, Saturday September 28th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1418,
+    "label": "12am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T05:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1409,
+    "label": "1am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T06:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1408,
+    "label": "2am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T07:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1401,
+    "label": "3am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T08:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1396,
+    "label": "4am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T09:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1388,
+    "label": "5am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T10:30:02.000Z",
+    "Bikes in use": 10,
+    "Bikes available": 1367,
+    "label": "6am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T11:30:02.000Z",
+    "Bikes in use": 60,
+    "Bikes available": 1317,
+    "label": "7am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T12:30:02.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "8am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T13:30:02.000Z",
+    "Bikes in use": 61,
+    "Bikes available": 1316,
+    "label": "9am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T14:30:02.000Z",
+    "Bikes in use": 85,
+    "Bikes available": 1292,
+    "label": "10am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T15:30:02.000Z",
+    "Bikes in use": 94,
+    "Bikes available": 1283,
+    "label": "11am, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T16:30:02.000Z",
+    "Bikes in use": 75,
+    "Bikes available": 1302,
+    "label": "12pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T17:30:03.000Z",
+    "Bikes in use": 117,
+    "Bikes available": 1260,
+    "label": "1pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T18:30:02.000Z",
+    "Bikes in use": 30,
+    "Bikes available": 1347,
+    "label": "2pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T19:30:02.000Z",
+    "Bikes in use": 13,
+    "Bikes available": 1364,
+    "label": "3pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T20:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1379,
+    "label": "4pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T21:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1396,
+    "label": "5pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T22:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1401,
+    "label": "6pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-29T23:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1401,
+    "label": "7pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1410,
+    "label": "8pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T01:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1416,
+    "label": "9pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1416,
+    "label": "10pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1416,
+    "label": "11pm, Sunday September 29th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1392,
+    "label": "12am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T05:30:02.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "1am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T06:30:03.000Z",
+    "Bikes in use": 91,
+    "Bikes available": 1286,
+    "label": "2am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T07:30:03.000Z",
+    "Bikes in use": 367,
+    "Bikes available": 1010,
+    "label": "3am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T08:30:03.000Z",
+    "Bikes in use": 207,
+    "Bikes available": 1170,
+    "label": "4am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T09:30:03.000Z",
+    "Bikes in use": 137,
+    "Bikes available": 1240,
+    "label": "5am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T10:30:02.000Z",
+    "Bikes in use": 140,
+    "Bikes available": 1237,
+    "label": "6am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T11:30:02.000Z",
+    "Bikes in use": 111,
+    "Bikes available": 1266,
+    "label": "7am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T12:30:03.000Z",
+    "Bikes in use": 111,
+    "Bikes available": 1266,
+    "label": "8am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T13:30:02.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "9am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T14:30:02.000Z",
+    "Bikes in use": 34,
+    "Bikes available": 1343,
+    "label": "10am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T15:30:03.000Z",
+    "Bikes in use": 31,
+    "Bikes available": 1346,
+    "label": "11am, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T16:30:02.000Z",
+    "Bikes in use": 120,
+    "Bikes available": 1257,
+    "label": "12pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T17:30:02.000Z",
+    "Bikes in use": 94,
+    "Bikes available": 1283,
+    "label": "1pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T18:30:02.000Z",
+    "Bikes in use": 30,
+    "Bikes available": 1347,
+    "label": "2pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T19:30:02.000Z",
+    "Bikes in use": 4,
+    "Bikes available": 1373,
+    "label": "3pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T20:30:03.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "4pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T21:30:02.000Z",
+    "Bikes in use": 8,
+    "Bikes available": 1369,
+    "label": "5pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T22:30:03.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "6pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-09-30T23:30:02.000Z",
+    "Bikes in use": 1,
+    "Bikes available": 1376,
+    "label": "7pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1382,
+    "label": "8pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T01:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1384,
+    "label": "9pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1384,
+    "label": "10pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1384,
+    "label": "11pm, Monday September 30th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T04:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1382,
+    "label": "12am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T05:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "1am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T06:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "2am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T07:30:02.000Z",
+    "Bikes in use": 224,
+    "Bikes available": 1153,
+    "label": "3am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T08:30:02.000Z",
+    "Bikes in use": 167,
+    "Bikes available": 1210,
+    "label": "4am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T09:30:02.000Z",
+    "Bikes in use": 80,
+    "Bikes available": 1297,
+    "label": "5am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T10:30:02.000Z",
+    "Bikes in use": 48,
+    "Bikes available": 1329,
+    "label": "6am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T11:30:02.000Z",
+    "Bikes in use": 75,
+    "Bikes available": 1302,
+    "label": "7am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T12:30:03.000Z",
+    "Bikes in use": 78,
+    "Bikes available": 1299,
+    "label": "8am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T13:30:02.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "9am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T14:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "10am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T15:30:02.000Z",
+    "Bikes in use": 91,
+    "Bikes available": 1286,
+    "label": "11am, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T16:30:27.000Z",
+    "Bikes in use": 226,
+    "Bikes available": 1151,
+    "label": "12pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T17:30:02.000Z",
+    "Bikes in use": 200,
+    "Bikes available": 1177,
+    "label": "1pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T18:30:02.000Z",
+    "Bikes in use": 77,
+    "Bikes available": 1300,
+    "label": "2pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T19:30:02.000Z",
+    "Bikes in use": 37,
+    "Bikes available": 1340,
+    "label": "3pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T20:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "4pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T21:30:02.000Z",
+    "Bikes in use": 4,
+    "Bikes available": 1373,
+    "label": "5pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T22:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1392,
+    "label": "6pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-01T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1394,
+    "label": "7pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1398,
+    "label": "8pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "9pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "10pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "11pm, Tuesday October 1st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1383,
+    "label": "12am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T05:30:03.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "1am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T06:30:02.000Z",
+    "Bikes in use": 116,
+    "Bikes available": 1261,
+    "label": "2am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T07:30:03.000Z",
+    "Bikes in use": 388,
+    "Bikes available": 989,
+    "label": "3am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T08:30:02.000Z",
+    "Bikes in use": 214,
+    "Bikes available": 1163,
+    "label": "4am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T09:30:03.000Z",
+    "Bikes in use": 92,
+    "Bikes available": 1285,
+    "label": "5am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T10:30:02.000Z",
+    "Bikes in use": 114,
+    "Bikes available": 1263,
+    "label": "6am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T11:30:02.000Z",
+    "Bikes in use": 169,
+    "Bikes available": 1208,
+    "label": "7am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T12:30:02.000Z",
+    "Bikes in use": 172,
+    "Bikes available": 1205,
+    "label": "8am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T13:30:02.000Z",
+    "Bikes in use": 104,
+    "Bikes available": 1273,
+    "label": "9am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T14:30:02.000Z",
+    "Bikes in use": 85,
+    "Bikes available": 1292,
+    "label": "10am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T15:30:02.000Z",
+    "Bikes in use": 159,
+    "Bikes available": 1218,
+    "label": "11am, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T16:30:03.000Z",
+    "Bikes in use": 301,
+    "Bikes available": 1076,
+    "label": "12pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T17:30:02.000Z",
+    "Bikes in use": 210,
+    "Bikes available": 1167,
+    "label": "1pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T18:30:02.000Z",
+    "Bikes in use": 113,
+    "Bikes available": 1264,
+    "label": "2pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T19:30:02.000Z",
+    "Bikes in use": 25,
+    "Bikes available": 1352,
+    "label": "3pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T20:30:02.000Z",
+    "Bikes in use": 47,
+    "Bikes available": 1330,
+    "label": "4pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T21:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "5pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T22:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "6pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-02T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1383,
+    "label": "7pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "8pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T01:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "9pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T02:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "10pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "11pm, Wednesday October 2nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1395,
+    "label": "12am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T05:30:02.000Z",
+    "Bikes in use": 32,
+    "Bikes available": 1345,
+    "label": "1am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T06:30:02.000Z",
+    "Bikes in use": 100,
+    "Bikes available": 1277,
+    "label": "2am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T07:30:03.000Z",
+    "Bikes in use": 401,
+    "Bikes available": 976,
+    "label": "3am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T08:30:02.000Z",
+    "Bikes in use": 202,
+    "Bikes available": 1175,
+    "label": "4am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T09:30:02.000Z",
+    "Bikes in use": 111,
+    "Bikes available": 1266,
+    "label": "5am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T10:30:03.000Z",
+    "Bikes in use": 58,
+    "Bikes available": 1319,
+    "label": "6am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T11:30:02.000Z",
+    "Bikes in use": 134,
+    "Bikes available": 1243,
+    "label": "7am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T12:30:03.000Z",
+    "Bikes in use": 131,
+    "Bikes available": 1246,
+    "label": "8am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T13:30:02.000Z",
+    "Bikes in use": 61,
+    "Bikes available": 1316,
+    "label": "9am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T14:30:03.000Z",
+    "Bikes in use": 44,
+    "Bikes available": 1333,
+    "label": "10am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T15:30:02.000Z",
+    "Bikes in use": 88,
+    "Bikes available": 1289,
+    "label": "11am, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T16:30:02.000Z",
+    "Bikes in use": 215,
+    "Bikes available": 1162,
+    "label": "12pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T17:30:02.000Z",
+    "Bikes in use": 211,
+    "Bikes available": 1166,
+    "label": "1pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T18:30:02.000Z",
+    "Bikes in use": 69,
+    "Bikes available": 1308,
+    "label": "2pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T19:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "3pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T20:30:03.000Z",
+    "Bikes in use": 33,
+    "Bikes available": 1344,
+    "label": "4pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T21:30:02.000Z",
+    "Bikes in use": 33,
+    "Bikes available": 1344,
+    "label": "5pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T22:30:02.000Z",
+    "Bikes in use": 13,
+    "Bikes available": 1364,
+    "label": "6pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-03T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1379,
+    "label": "7pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T00:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1385,
+    "label": "8pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1387,
+    "label": "9pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1387,
+    "label": "10pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1387,
+    "label": "11pm, Thursday October 3rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T04:30:03.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "12am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T05:30:03.000Z",
+    "Bikes in use": 9,
+    "Bikes available": 1368,
+    "label": "1am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T06:30:03.000Z",
+    "Bikes in use": 87,
+    "Bikes available": 1290,
+    "label": "2am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T07:30:02.000Z",
+    "Bikes in use": 137,
+    "Bikes available": 1240,
+    "label": "3am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T08:30:02.000Z",
+    "Bikes in use": 82,
+    "Bikes available": 1295,
+    "label": "4am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T09:30:02.000Z",
+    "Bikes in use": 80,
+    "Bikes available": 1297,
+    "label": "5am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T10:30:03.000Z",
+    "Bikes in use": 45,
+    "Bikes available": 1332,
+    "label": "6am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T11:30:02.000Z",
+    "Bikes in use": 95,
+    "Bikes available": 1282,
+    "label": "7am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T12:30:02.000Z",
+    "Bikes in use": 161,
+    "Bikes available": 1216,
+    "label": "8am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T13:30:02.000Z",
+    "Bikes in use": 81,
+    "Bikes available": 1296,
+    "label": "9am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T14:30:03.000Z",
+    "Bikes in use": 68,
+    "Bikes available": 1309,
+    "label": "10am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T15:30:03.000Z",
+    "Bikes in use": 129,
+    "Bikes available": 1248,
+    "label": "11am, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T16:30:02.000Z",
+    "Bikes in use": 261,
+    "Bikes available": 1116,
+    "label": "12pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T17:30:02.000Z",
+    "Bikes in use": 166,
+    "Bikes available": 1211,
+    "label": "1pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T18:30:02.000Z",
+    "Bikes in use": 100,
+    "Bikes available": 1277,
+    "label": "2pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T19:30:02.000Z",
+    "Bikes in use": 43,
+    "Bikes available": 1334,
+    "label": "3pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T20:30:02.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "4pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T21:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1386,
+    "label": "5pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T22:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "6pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-04T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1388,
+    "label": "7pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T00:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1418,
+    "label": "8pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1419,
+    "label": "9pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T02:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1419,
+    "label": "10pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T03:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1421,
+    "label": "11pm, Friday October 4th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T04:30:28.000Z",
     "Bikes in use": 0,
     "Bikes available": 1414,
-    "label": "1am, Monday September 23rd",
+    "label": "12am, Saturday October 5th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T02:00:02.000Z",
+    "date": "2019-10-05T05:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1401,
+    "label": "1am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T06:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1396,
+    "label": "2am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T07:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1387,
+    "label": "3am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T08:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1383,
+    "label": "4am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T09:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "5am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T10:30:02.000Z",
+    "Bikes in use": 54,
+    "Bikes available": 1323,
+    "label": "6am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T11:30:02.000Z",
+    "Bikes in use": 55,
+    "Bikes available": 1322,
+    "label": "7am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T12:30:03.000Z",
+    "Bikes in use": 49,
+    "Bikes available": 1328,
+    "label": "8am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T13:30:03.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "9am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T14:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1383,
+    "label": "10am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T15:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1395,
+    "label": "11am, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T16:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1390,
+    "label": "12pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T17:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1386,
+    "label": "1pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T18:30:02.000Z",
+    "Bikes in use": 10,
+    "Bikes available": 1367,
+    "label": "2pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T19:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1400,
+    "label": "3pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T20:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1398,
+    "label": "4pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T21:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1389,
+    "label": "5pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T22:30:02.000Z",
+    "Bikes in use": 2,
+    "Bikes available": 1375,
+    "label": "6pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-05T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1385,
+    "label": "7pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1413,
+    "label": "8pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T01:30:02.000Z",
     "Bikes in use": 0,
     "Bikes available": 1415,
-    "label": "2am, Monday September 23rd",
+    "label": "9pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1416,
+    "label": "10pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1417,
+    "label": "11pm, Saturday October 5th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1410,
+    "label": "12am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T05:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1400,
+    "label": "1am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T06:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1394,
+    "label": "2am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T07:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1404,
+    "label": "3am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T08:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "4am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T09:30:02.000Z",
+    "Bikes in use": 4,
+    "Bikes available": 1373,
+    "label": "5am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T10:30:02.000Z",
+    "Bikes in use": 49,
+    "Bikes available": 1328,
+    "label": "6am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T11:30:02.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "7am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T12:30:02.000Z",
+    "Bikes in use": 72,
+    "Bikes available": 1305,
+    "label": "8am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T13:30:03.000Z",
+    "Bikes in use": 77,
+    "Bikes available": 1300,
+    "label": "9am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T14:30:03.000Z",
+    "Bikes in use": 99,
+    "Bikes available": 1278,
+    "label": "10am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T15:30:02.000Z",
+    "Bikes in use": 84,
+    "Bikes available": 1293,
+    "label": "11am, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T16:30:02.000Z",
+    "Bikes in use": 95,
+    "Bikes available": 1282,
+    "label": "12pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T17:30:02.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "1pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T18:30:02.000Z",
+    "Bikes in use": 36,
+    "Bikes available": 1341,
+    "label": "2pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T19:30:02.000Z",
+    "Bikes in use": 13,
+    "Bikes available": 1364,
+    "label": "3pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T20:30:02.000Z",
+    "Bikes in use": 2,
+    "Bikes available": 1375,
+    "label": "4pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T21:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1378,
+    "label": "5pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T22:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1383,
+    "label": "6pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-06T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1394,
+    "label": "7pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T00:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1397,
+    "label": "8pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1398,
+    "label": "9pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "10pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1399,
+    "label": "11pm, Sunday October 6th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T04:30:03.000Z",
+    "Bikes in use": 9,
+    "Bikes available": 1368,
+    "label": "12am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T05:30:02.000Z",
+    "Bikes in use": 43,
+    "Bikes available": 1334,
+    "label": "1am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T06:30:02.000Z",
+    "Bikes in use": 135,
+    "Bikes available": 1242,
+    "label": "2am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T07:30:02.000Z",
+    "Bikes in use": 307,
+    "Bikes available": 1070,
+    "label": "3am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T08:30:02.000Z",
+    "Bikes in use": 222,
+    "Bikes available": 1155,
+    "label": "4am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T09:30:02.000Z",
+    "Bikes in use": 128,
+    "Bikes available": 1249,
+    "label": "5am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T10:30:02.000Z",
+    "Bikes in use": 104,
+    "Bikes available": 1273,
+    "label": "6am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T11:30:02.000Z",
+    "Bikes in use": 159,
+    "Bikes available": 1218,
+    "label": "7am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T12:30:02.000Z",
+    "Bikes in use": 183,
+    "Bikes available": 1194,
+    "label": "8am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T13:30:03.000Z",
+    "Bikes in use": 120,
+    "Bikes available": 1257,
+    "label": "9am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T14:30:27.000Z",
+    "Bikes in use": 73,
+    "Bikes available": 1304,
+    "label": "10am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T15:30:02.000Z",
+    "Bikes in use": 170,
+    "Bikes available": 1207,
+    "label": "11am, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T16:30:03.000Z",
+    "Bikes in use": 321,
+    "Bikes available": 1056,
+    "label": "12pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T17:30:02.000Z",
+    "Bikes in use": 258,
+    "Bikes available": 1119,
+    "label": "1pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T18:30:02.000Z",
+    "Bikes in use": 150,
+    "Bikes available": 1227,
+    "label": "2pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T19:30:02.000Z",
+    "Bikes in use": 86,
+    "Bikes available": 1291,
+    "label": "3pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T20:30:02.000Z",
+    "Bikes in use": 64,
+    "Bikes available": 1313,
+    "label": "4pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T21:30:02.000Z",
+    "Bikes in use": 30,
+    "Bikes available": 1347,
+    "label": "5pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T22:30:03.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "6pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-07T23:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "7pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T00:30:02.000Z",
+    "Bikes in use": 19,
+    "Bikes available": 1358,
+    "label": "8pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T01:30:02.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "9pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T02:30:03.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "10pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T03:30:02.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "11pm, Monday October 7th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1387,
+    "label": "12am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T05:30:02.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "1am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T06:30:02.000Z",
+    "Bikes in use": 150,
+    "Bikes available": 1227,
+    "label": "2am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T07:30:02.000Z",
+    "Bikes in use": 425,
+    "Bikes available": 952,
+    "label": "3am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T08:30:02.000Z",
+    "Bikes in use": 254,
+    "Bikes available": 1123,
+    "label": "4am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T09:30:02.000Z",
+    "Bikes in use": 122,
+    "Bikes available": 1255,
+    "label": "5am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T10:30:02.000Z",
+    "Bikes in use": 98,
+    "Bikes available": 1279,
+    "label": "6am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T11:30:02.000Z",
+    "Bikes in use": 179,
+    "Bikes available": 1198,
+    "label": "7am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T12:30:02.000Z",
+    "Bikes in use": 203,
+    "Bikes available": 1174,
+    "label": "8am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T13:30:02.000Z",
+    "Bikes in use": 109,
+    "Bikes available": 1268,
+    "label": "9am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T14:30:02.000Z",
+    "Bikes in use": 80,
+    "Bikes available": 1297,
+    "label": "10am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T15:30:03.000Z",
+    "Bikes in use": 167,
+    "Bikes available": 1210,
+    "label": "11am, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T16:30:02.000Z",
+    "Bikes in use": 315,
+    "Bikes available": 1062,
+    "label": "12pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T17:30:03.000Z",
+    "Bikes in use": 274,
+    "Bikes available": 1103,
+    "label": "1pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T18:30:02.000Z",
+    "Bikes in use": 123,
+    "Bikes available": 1254,
+    "label": "2pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T19:30:02.000Z",
+    "Bikes in use": 68,
+    "Bikes available": 1309,
+    "label": "3pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T20:30:02.000Z",
+    "Bikes in use": 69,
+    "Bikes available": 1308,
+    "label": "4pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T21:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "5pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T22:30:02.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "6pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-08T23:30:02.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "7pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T00:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "8pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T01:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "9pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T02:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "10pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T03:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "11pm, Tuesday October 8th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T04:30:02.000Z",
+    "Bikes in use": 2,
+    "Bikes available": 1375,
+    "label": "12am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T05:30:02.000Z",
+    "Bikes in use": 51,
+    "Bikes available": 1326,
+    "label": "1am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T06:30:02.000Z",
+    "Bikes in use": 121,
+    "Bikes available": 1256,
+    "label": "2am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T07:30:03.000Z",
+    "Bikes in use": 394,
+    "Bikes available": 983,
+    "label": "3am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T08:30:03.000Z",
+    "Bikes in use": 187,
+    "Bikes available": 1190,
+    "label": "4am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T09:30:03.000Z",
+    "Bikes in use": 125,
+    "Bikes available": 1252,
+    "label": "5am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T10:30:02.000Z",
+    "Bikes in use": 81,
+    "Bikes available": 1296,
+    "label": "6am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T11:30:02.000Z",
+    "Bikes in use": 162,
+    "Bikes available": 1215,
+    "label": "7am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T12:30:02.000Z",
+    "Bikes in use": 195,
+    "Bikes available": 1182,
+    "label": "8am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T13:30:02.000Z",
+    "Bikes in use": 100,
+    "Bikes available": 1277,
+    "label": "9am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T14:30:03.000Z",
+    "Bikes in use": 67,
+    "Bikes available": 1310,
+    "label": "10am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T15:30:02.000Z",
+    "Bikes in use": 159,
+    "Bikes available": 1218,
+    "label": "11am, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T16:30:02.000Z",
+    "Bikes in use": 318,
+    "Bikes available": 1059,
+    "label": "12pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T17:30:02.000Z",
+    "Bikes in use": 211,
+    "Bikes available": 1166,
+    "label": "1pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T18:30:02.000Z",
+    "Bikes in use": 139,
+    "Bikes available": 1238,
+    "label": "2pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T19:30:02.000Z",
+    "Bikes in use": 59,
+    "Bikes available": 1318,
+    "label": "3pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T20:30:02.000Z",
+    "Bikes in use": 47,
+    "Bikes available": 1330,
+    "label": "4pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T21:30:02.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "5pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T22:30:02.000Z",
+    "Bikes in use": 33,
+    "Bikes available": 1344,
+    "label": "6pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-09T23:30:02.000Z",
+    "Bikes in use": 23,
+    "Bikes available": 1354,
+    "label": "7pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T00:30:03.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "8pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T01:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "9pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T02:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "10pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T03:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "11pm, Wednesday October 9th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T04:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1403,
+    "label": "12am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T05:30:02.000Z",
+    "Bikes in use": 78,
+    "Bikes available": 1299,
+    "label": "1am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T06:30:02.000Z",
+    "Bikes in use": 140,
+    "Bikes available": 1237,
+    "label": "2am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T07:30:02.000Z",
+    "Bikes in use": 448,
+    "Bikes available": 929,
+    "label": "3am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T08:30:02.000Z",
+    "Bikes in use": 204,
+    "Bikes available": 1173,
+    "label": "4am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T09:30:02.000Z",
+    "Bikes in use": 80,
+    "Bikes available": 1297,
+    "label": "5am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T10:30:03.000Z",
+    "Bikes in use": 115,
+    "Bikes available": 1262,
+    "label": "6am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T11:30:02.000Z",
+    "Bikes in use": 148,
+    "Bikes available": 1229,
+    "label": "7am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T12:30:02.000Z",
+    "Bikes in use": 198,
+    "Bikes available": 1179,
+    "label": "8am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T13:30:02.000Z",
+    "Bikes in use": 117,
+    "Bikes available": 1260,
+    "label": "9am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T14:30:02.000Z",
+    "Bikes in use": 85,
+    "Bikes available": 1292,
+    "label": "10am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T15:30:02.000Z",
+    "Bikes in use": 122,
+    "Bikes available": 1255,
+    "label": "11am, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T16:30:02.000Z",
+    "Bikes in use": 280,
+    "Bikes available": 1097,
+    "label": "12pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T17:30:02.000Z",
+    "Bikes in use": 210,
+    "Bikes available": 1167,
+    "label": "1pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T18:30:02.000Z",
+    "Bikes in use": 133,
+    "Bikes available": 1244,
+    "label": "2pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T19:30:02.000Z",
+    "Bikes in use": 60,
+    "Bikes available": 1317,
+    "label": "3pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T20:30:02.000Z",
+    "Bikes in use": 40,
+    "Bikes available": 1337,
+    "label": "4pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T21:30:02.000Z",
+    "Bikes in use": 22,
+    "Bikes available": 1355,
+    "label": "5pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T22:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "6pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-10T23:30:02.000Z",
+    "Bikes in use": 18,
+    "Bikes available": 1359,
+    "label": "7pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T00:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "8pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T01:30:02.000Z",
+    "Bikes in use": 8,
+    "Bikes available": 1369,
+    "label": "9pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T02:30:03.000Z",
+    "Bikes in use": 8,
+    "Bikes available": 1369,
+    "label": "10pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T03:30:02.000Z",
+    "Bikes in use": 8,
+    "Bikes available": 1369,
+    "label": "11pm, Thursday October 10th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T04:30:02.000Z",
+    "Bikes in use": 13,
+    "Bikes available": 1364,
+    "label": "12am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T05:30:02.000Z",
+    "Bikes in use": 63,
+    "Bikes available": 1314,
+    "label": "1am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T06:30:02.000Z",
+    "Bikes in use": 121,
+    "Bikes available": 1256,
+    "label": "2am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T07:30:02.000Z",
+    "Bikes in use": 378,
+    "Bikes available": 999,
+    "label": "3am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T08:30:02.000Z",
+    "Bikes in use": 151,
+    "Bikes available": 1226,
+    "label": "4am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T09:30:27.000Z",
+    "Bikes in use": 86,
+    "Bikes available": 1291,
+    "label": "5am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T10:30:03.000Z",
+    "Bikes in use": 84,
+    "Bikes available": 1293,
+    "label": "6am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T11:30:02.000Z",
+    "Bikes in use": 177,
+    "Bikes available": 1200,
+    "label": "7am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T12:30:03.000Z",
+    "Bikes in use": 187,
+    "Bikes available": 1190,
+    "label": "8am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T13:30:02.000Z",
+    "Bikes in use": 100,
+    "Bikes available": 1277,
+    "label": "9am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T14:30:03.000Z",
+    "Bikes in use": 112,
+    "Bikes available": 1265,
+    "label": "10am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T15:30:03.000Z",
+    "Bikes in use": 154,
+    "Bikes available": 1223,
+    "label": "11am, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T16:30:02.000Z",
+    "Bikes in use": 276,
+    "Bikes available": 1101,
+    "label": "12pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T17:30:02.000Z",
+    "Bikes in use": 201,
+    "Bikes available": 1176,
+    "label": "1pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T18:30:02.000Z",
+    "Bikes in use": 102,
+    "Bikes available": 1275,
+    "label": "2pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T19:30:02.000Z",
+    "Bikes in use": 79,
+    "Bikes available": 1298,
+    "label": "3pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T20:30:02.000Z",
+    "Bikes in use": 64,
+    "Bikes available": 1313,
+    "label": "4pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T21:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "5pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T22:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "6pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-11T23:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1378,
+    "label": "7pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1401,
+    "label": "8pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T01:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1403,
+    "label": "9pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1403,
+    "label": "10pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1404,
+    "label": "11pm, Friday October 11th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T04:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1400,
+    "label": "12am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T05:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1389,
+    "label": "1am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T06:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1386,
+    "label": "2am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T07:30:03.000Z",
+    "Bikes in use": 10,
+    "Bikes available": 1367,
+    "label": "3am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T08:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "4am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T09:30:03.000Z",
+    "Bikes in use": 59,
+    "Bikes available": 1318,
+    "label": "5am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T10:30:02.000Z",
+    "Bikes in use": 77,
+    "Bikes available": 1300,
+    "label": "6am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T11:30:02.000Z",
+    "Bikes in use": 102,
+    "Bikes available": 1275,
+    "label": "7am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T12:30:02.000Z",
+    "Bikes in use": 127,
+    "Bikes available": 1250,
+    "label": "8am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T13:30:03.000Z",
+    "Bikes in use": 133,
+    "Bikes available": 1244,
+    "label": "9am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T14:30:02.000Z",
+    "Bikes in use": 116,
+    "Bikes available": 1261,
+    "label": "10am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T15:30:02.000Z",
+    "Bikes in use": 111,
+    "Bikes available": 1266,
+    "label": "11am, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T16:30:03.000Z",
+    "Bikes in use": 136,
+    "Bikes available": 1241,
+    "label": "12pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T17:30:02.000Z",
+    "Bikes in use": 41,
+    "Bikes available": 1336,
+    "label": "1pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T18:30:03.000Z",
+    "Bikes in use": 58,
+    "Bikes available": 1319,
+    "label": "2pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T19:30:02.000Z",
+    "Bikes in use": 30,
+    "Bikes available": 1347,
+    "label": "3pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T20:30:03.000Z",
+    "Bikes in use": 13,
+    "Bikes available": 1364,
+    "label": "4pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T21:30:03.000Z",
+    "Bikes in use": 13,
+    "Bikes available": 1364,
+    "label": "5pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T22:30:03.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "6pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-12T23:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "7pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T00:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1386,
+    "label": "8pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1389,
+    "label": "9pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T02:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1391,
+    "label": "10pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T03:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1392,
+    "label": "11pm, Saturday October 12th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T04:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1392,
+    "label": "12am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T05:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "1am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T06:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1382,
+    "label": "2am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T07:30:02.000Z",
+    "Bikes in use": 19,
+    "Bikes available": 1358,
+    "label": "3am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T08:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "4am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T09:30:02.000Z",
+    "Bikes in use": 23,
+    "Bikes available": 1354,
+    "label": "5am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T10:30:02.000Z",
+    "Bikes in use": 16,
+    "Bikes available": 1361,
+    "label": "6am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T11:30:02.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "7am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T12:30:03.000Z",
+    "Bikes in use": 33,
+    "Bikes available": 1344,
+    "label": "8am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T13:30:02.000Z",
+    "Bikes in use": 61,
+    "Bikes available": 1316,
+    "label": "9am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T14:30:03.000Z",
+    "Bikes in use": 60,
+    "Bikes available": 1317,
+    "label": "10am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T15:30:03.000Z",
+    "Bikes in use": 77,
+    "Bikes available": 1300,
+    "label": "11am, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T16:30:02.000Z",
+    "Bikes in use": 69,
+    "Bikes available": 1308,
+    "label": "12pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T17:30:02.000Z",
+    "Bikes in use": 67,
+    "Bikes available": 1310,
+    "label": "1pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T18:30:02.000Z",
+    "Bikes in use": 52,
+    "Bikes available": 1325,
+    "label": "2pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T19:30:02.000Z",
+    "Bikes in use": 37,
+    "Bikes available": 1340,
+    "label": "3pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T20:30:03.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "4pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T21:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "5pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T22:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "6pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-13T23:30:02.000Z",
+    "Bikes in use": 7,
+    "Bikes available": 1370,
+    "label": "7pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T00:30:02.000Z",
+    "Bikes in use": 3,
+    "Bikes available": 1374,
+    "label": "8pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T01:30:02.000Z",
+    "Bikes in use": 1,
+    "Bikes available": 1376,
+    "label": "9pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "10pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "11pm, Sunday October 13th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T04:30:03.000Z",
+    "Bikes in use": 4,
+    "Bikes available": 1373,
+    "label": "12am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T05:30:02.000Z",
+    "Bikes in use": 107,
+    "Bikes available": 1270,
+    "label": "1am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T06:30:02.000Z",
+    "Bikes in use": 165,
+    "Bikes available": 1212,
+    "label": "2am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T07:30:02.000Z",
+    "Bikes in use": 258,
+    "Bikes available": 1119,
+    "label": "3am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T08:30:03.000Z",
+    "Bikes in use": 217,
+    "Bikes available": 1160,
+    "label": "4am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T09:30:02.000Z",
+    "Bikes in use": 140,
+    "Bikes available": 1237,
+    "label": "5am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T10:30:02.000Z",
+    "Bikes in use": 107,
+    "Bikes available": 1270,
+    "label": "6am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T11:30:03.000Z",
+    "Bikes in use": 149,
+    "Bikes available": 1228,
+    "label": "7am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T12:30:02.000Z",
+    "Bikes in use": 189,
+    "Bikes available": 1188,
+    "label": "8am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T13:30:02.000Z",
+    "Bikes in use": 128,
+    "Bikes available": 1249,
+    "label": "9am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T14:30:02.000Z",
+    "Bikes in use": 92,
+    "Bikes available": 1285,
+    "label": "10am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T15:30:02.000Z",
+    "Bikes in use": 169,
+    "Bikes available": 1208,
+    "label": "11am, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T16:30:02.000Z",
+    "Bikes in use": 274,
+    "Bikes available": 1103,
+    "label": "12pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T17:30:02.000Z",
+    "Bikes in use": 248,
+    "Bikes available": 1129,
+    "label": "1pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T18:30:02.000Z",
+    "Bikes in use": 150,
+    "Bikes available": 1227,
+    "label": "2pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T19:30:02.000Z",
+    "Bikes in use": 109,
+    "Bikes available": 1268,
+    "label": "3pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T20:30:02.000Z",
+    "Bikes in use": 55,
+    "Bikes available": 1322,
+    "label": "4pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T21:30:02.000Z",
+    "Bikes in use": 48,
+    "Bikes available": 1329,
+    "label": "5pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T22:30:02.000Z",
+    "Bikes in use": 41,
+    "Bikes available": 1336,
+    "label": "6pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-14T23:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "7pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T00:30:03.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "8pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T01:30:03.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "9pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T02:30:02.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "10pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T03:30:02.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "11pm, Monday October 14th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T04:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "12am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T05:30:02.000Z",
+    "Bikes in use": 77,
+    "Bikes available": 1300,
+    "label": "1am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T06:30:03.000Z",
+    "Bikes in use": 169,
+    "Bikes available": 1208,
+    "label": "2am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T07:30:03.000Z",
+    "Bikes in use": 426,
+    "Bikes available": 951,
+    "label": "3am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T08:30:02.000Z",
+    "Bikes in use": 197,
+    "Bikes available": 1180,
+    "label": "4am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T09:30:03.000Z",
+    "Bikes in use": 122,
+    "Bikes available": 1255,
+    "label": "5am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T10:30:03.000Z",
+    "Bikes in use": 133,
+    "Bikes available": 1244,
+    "label": "6am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T11:30:03.000Z",
+    "Bikes in use": 222,
+    "Bikes available": 1155,
+    "label": "7am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T12:30:28.000Z",
+    "Bikes in use": 234,
+    "Bikes available": 1143,
+    "label": "8am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T13:30:02.000Z",
+    "Bikes in use": 90,
+    "Bikes available": 1287,
+    "label": "9am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T14:30:02.000Z",
+    "Bikes in use": 114,
+    "Bikes available": 1263,
+    "label": "10am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T15:30:02.000Z",
+    "Bikes in use": 172,
+    "Bikes available": 1205,
+    "label": "11am, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T16:30:02.000Z",
+    "Bikes in use": 364,
+    "Bikes available": 1013,
+    "label": "12pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T17:30:02.000Z",
+    "Bikes in use": 263,
+    "Bikes available": 1114,
+    "label": "1pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T18:30:02.000Z",
+    "Bikes in use": 150,
+    "Bikes available": 1227,
+    "label": "2pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T19:30:03.000Z",
+    "Bikes in use": 91,
+    "Bikes available": 1286,
+    "label": "3pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T20:30:03.000Z",
+    "Bikes in use": 100,
+    "Bikes available": 1277,
+    "label": "4pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T21:30:03.000Z",
+    "Bikes in use": 57,
+    "Bikes available": 1320,
+    "label": "5pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T22:30:02.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "6pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-15T23:30:02.000Z",
+    "Bikes in use": 34,
+    "Bikes available": 1343,
+    "label": "7pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T00:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "8pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T01:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "9pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T02:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "10pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T03:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "11pm, Tuesday October 15th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T04:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "12am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T05:30:02.000Z",
+    "Bikes in use": 104,
+    "Bikes available": 1273,
+    "label": "1am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T06:30:03.000Z",
+    "Bikes in use": 135,
+    "Bikes available": 1242,
+    "label": "2am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T07:30:02.000Z",
+    "Bikes in use": 449,
+    "Bikes available": 928,
+    "label": "3am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T08:30:02.000Z",
+    "Bikes in use": 202,
+    "Bikes available": 1175,
+    "label": "4am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T09:30:02.000Z",
+    "Bikes in use": 144,
+    "Bikes available": 1233,
+    "label": "5am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T10:30:02.000Z",
+    "Bikes in use": 148,
+    "Bikes available": 1229,
+    "label": "6am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T11:30:02.000Z",
+    "Bikes in use": 249,
+    "Bikes available": 1128,
+    "label": "7am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T12:30:03.000Z",
+    "Bikes in use": 250,
+    "Bikes available": 1127,
+    "label": "8am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T13:30:03.000Z",
+    "Bikes in use": 141,
+    "Bikes available": 1236,
+    "label": "9am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T14:30:03.000Z",
+    "Bikes in use": 134,
+    "Bikes available": 1243,
+    "label": "10am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T15:30:02.000Z",
+    "Bikes in use": 202,
+    "Bikes available": 1175,
+    "label": "11am, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T16:30:02.000Z",
+    "Bikes in use": 360,
+    "Bikes available": 1017,
+    "label": "12pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T17:30:02.000Z",
+    "Bikes in use": 278,
+    "Bikes available": 1099,
+    "label": "1pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T18:30:03.000Z",
+    "Bikes in use": 164,
+    "Bikes available": 1213,
+    "label": "2pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T19:30:03.000Z",
+    "Bikes in use": 101,
+    "Bikes available": 1276,
+    "label": "3pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T20:30:02.000Z",
+    "Bikes in use": 68,
+    "Bikes available": 1309,
+    "label": "4pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T21:30:02.000Z",
+    "Bikes in use": 51,
+    "Bikes available": 1326,
+    "label": "5pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T22:30:02.000Z",
+    "Bikes in use": 63,
+    "Bikes available": 1314,
+    "label": "6pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-16T23:30:03.000Z",
+    "Bikes in use": 40,
+    "Bikes available": 1337,
+    "label": "7pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T00:30:03.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "8pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T01:30:02.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "9pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T02:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "10pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T03:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "11pm, Wednesday October 16th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T04:30:02.000Z",
+    "Bikes in use": 17,
+    "Bikes available": 1360,
+    "label": "12am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T05:30:03.000Z",
+    "Bikes in use": 83,
+    "Bikes available": 1294,
+    "label": "1am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T06:30:02.000Z",
+    "Bikes in use": 137,
+    "Bikes available": 1240,
+    "label": "2am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T07:30:03.000Z",
+    "Bikes in use": 444,
+    "Bikes available": 933,
+    "label": "3am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T08:30:02.000Z",
+    "Bikes in use": 222,
+    "Bikes available": 1155,
+    "label": "4am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T09:30:02.000Z",
+    "Bikes in use": 139,
+    "Bikes available": 1238,
+    "label": "5am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T10:30:02.000Z",
+    "Bikes in use": 122,
+    "Bikes available": 1255,
+    "label": "6am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T11:30:02.000Z",
+    "Bikes in use": 184,
+    "Bikes available": 1193,
+    "label": "7am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T12:30:02.000Z",
+    "Bikes in use": 206,
+    "Bikes available": 1171,
+    "label": "8am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T13:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "9am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T14:30:02.000Z",
+    "Bikes in use": 87,
+    "Bikes available": 1290,
+    "label": "10am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T15:30:02.000Z",
+    "Bikes in use": 123,
+    "Bikes available": 1254,
+    "label": "11am, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T16:30:03.000Z",
+    "Bikes in use": 274,
+    "Bikes available": 1103,
+    "label": "12pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T17:30:02.000Z",
+    "Bikes in use": 240,
+    "Bikes available": 1137,
+    "label": "1pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T18:30:03.000Z",
+    "Bikes in use": 142,
+    "Bikes available": 1235,
+    "label": "2pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T19:30:02.000Z",
+    "Bikes in use": 66,
+    "Bikes available": 1311,
+    "label": "3pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T20:30:03.000Z",
+    "Bikes in use": 40,
+    "Bikes available": 1337,
+    "label": "4pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T21:30:02.000Z",
+    "Bikes in use": 57,
+    "Bikes available": 1320,
+    "label": "5pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T22:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "6pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-17T23:30:02.000Z",
+    "Bikes in use": 31,
+    "Bikes available": 1346,
+    "label": "7pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T00:30:02.000Z",
+    "Bikes in use": 17,
+    "Bikes available": 1360,
+    "label": "8pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T01:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "9pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T02:30:02.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "10pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T03:30:03.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "11pm, Thursday October 17th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T04:30:02.000Z",
+    "Bikes in use": 53,
+    "Bikes available": 1324,
+    "label": "12am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T05:30:02.000Z",
+    "Bikes in use": 77,
+    "Bikes available": 1300,
+    "label": "1am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T06:30:03.000Z",
+    "Bikes in use": 115,
+    "Bikes available": 1262,
+    "label": "2am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T07:30:03.000Z",
+    "Bikes in use": 393,
+    "Bikes available": 984,
+    "label": "3am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T08:30:03.000Z",
+    "Bikes in use": 193,
+    "Bikes available": 1184,
+    "label": "4am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T09:30:02.000Z",
+    "Bikes in use": 126,
+    "Bikes available": 1251,
+    "label": "5am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T10:30:02.000Z",
+    "Bikes in use": 112,
+    "Bikes available": 1265,
+    "label": "6am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T11:30:02.000Z",
+    "Bikes in use": 186,
+    "Bikes available": 1191,
+    "label": "7am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T12:30:03.000Z",
+    "Bikes in use": 174,
+    "Bikes available": 1203,
+    "label": "8am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T13:30:03.000Z",
+    "Bikes in use": 105,
+    "Bikes available": 1272,
+    "label": "9am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T14:30:03.000Z",
+    "Bikes in use": 128,
+    "Bikes available": 1249,
+    "label": "10am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T15:30:02.000Z",
+    "Bikes in use": 183,
+    "Bikes available": 1194,
+    "label": "11am, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T16:30:02.000Z",
+    "Bikes in use": 270,
+    "Bikes available": 1107,
+    "label": "12pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T17:30:02.000Z",
+    "Bikes in use": 216,
+    "Bikes available": 1161,
+    "label": "1pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T18:30:02.000Z",
+    "Bikes in use": 85,
+    "Bikes available": 1292,
+    "label": "2pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T19:30:02.000Z",
+    "Bikes in use": 66,
+    "Bikes available": 1311,
+    "label": "3pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T20:30:03.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "4pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T21:30:02.000Z",
+    "Bikes in use": 32,
+    "Bikes available": 1345,
+    "label": "5pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T22:30:03.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "6pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-18T23:30:02.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "7pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T00:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1378,
+    "label": "8pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T01:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1381,
+    "label": "9pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T02:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1381,
+    "label": "10pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1381,
+    "label": "11pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T04:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1378,
+    "label": "12am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T05:30:02.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "1am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T06:30:02.000Z",
+    "Bikes in use": 25,
+    "Bikes available": 1352,
+    "label": "2am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T07:30:03.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "3am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T08:30:02.000Z",
+    "Bikes in use": 34,
+    "Bikes available": 1343,
+    "label": "4am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T09:30:02.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "5am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T10:30:27.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "6am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T11:30:02.000Z",
+    "Bikes in use": 68,
+    "Bikes available": 1309,
+    "label": "7am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T12:30:02.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "8am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T13:30:03.000Z",
+    "Bikes in use": 82,
+    "Bikes available": 1295,
+    "label": "9am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T14:30:03.000Z",
+    "Bikes in use": 111,
+    "Bikes available": 1266,
+    "label": "10am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T15:30:02.000Z",
+    "Bikes in use": 75,
+    "Bikes available": 1302,
+    "label": "11am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T16:30:03.000Z",
+    "Bikes in use": 105,
+    "Bikes available": 1272,
+    "label": "12pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T17:30:02.000Z",
+    "Bikes in use": 82,
+    "Bikes available": 1295,
+    "label": "1pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T18:30:02.000Z",
+    "Bikes in use": 75,
+    "Bikes available": 1302,
+    "label": "2pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T19:30:02.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "3pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T20:30:02.000Z",
+    "Bikes in use": 52,
+    "Bikes available": 1325,
+    "label": "4pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T21:30:02.000Z",
+    "Bikes in use": 48,
+    "Bikes available": 1329,
+    "label": "5pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T22:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "6pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T23:30:27.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "7pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T00:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "8pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T01:30:02.000Z",
+    "Bikes in use": 19,
+    "Bikes available": 1358,
+    "label": "9pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T02:30:02.000Z",
+    "Bikes in use": 16,
+    "Bikes available": 1361,
+    "label": "10pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T03:30:02.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "11pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T04:30:02.000Z",
+    "Bikes in use": 16,
+    "Bikes available": 1361,
+    "label": "12am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T05:30:02.000Z",
+    "Bikes in use": 25,
+    "Bikes available": 1352,
+    "label": "1am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T06:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "2am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T07:30:03.000Z",
+    "Bikes in use": 47,
+    "Bikes available": 1330,
+    "label": "3am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T08:30:02.000Z",
+    "Bikes in use": 39,
+    "Bikes available": 1338,
+    "label": "4am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T09:30:03.000Z",
+    "Bikes in use": 69,
+    "Bikes available": 1308,
+    "label": "5am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T10:30:02.000Z",
+    "Bikes in use": 83,
+    "Bikes available": 1294,
+    "label": "6am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T11:30:02.000Z",
+    "Bikes in use": 106,
+    "Bikes available": 1271,
+    "label": "7am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T12:30:02.000Z",
+    "Bikes in use": 128,
+    "Bikes available": 1249,
+    "label": "8am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T13:30:03.000Z",
+    "Bikes in use": 152,
+    "Bikes available": 1225,
+    "label": "9am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T14:30:02.000Z",
+    "Bikes in use": 162,
+    "Bikes available": 1215,
+    "label": "10am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T15:30:02.000Z",
+    "Bikes in use": 136,
+    "Bikes available": 1241,
+    "label": "11am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T16:30:03.000Z",
+    "Bikes in use": 112,
+    "Bikes available": 1265,
+    "label": "12pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T17:30:02.000Z",
+    "Bikes in use": 87,
+    "Bikes available": 1290,
+    "label": "1pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T18:30:02.000Z",
+    "Bikes in use": 65,
+    "Bikes available": 1312,
+    "label": "2pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T19:30:03.000Z",
+    "Bikes in use": 64,
+    "Bikes available": 1313,
+    "label": "3pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T20:30:02.000Z",
+    "Bikes in use": 47,
+    "Bikes available": 1330,
+    "label": "4pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T21:30:02.000Z",
+    "Bikes in use": 40,
+    "Bikes available": 1337,
+    "label": "5pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T22:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "6pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T23:30:03.000Z",
+    "Bikes in use": 25,
+    "Bikes available": 1352,
+    "label": "7pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T00:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "8pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T01:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "9pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T02:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "10pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T03:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "11pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T04:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "12am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T05:30:02.000Z",
+    "Bikes in use": 81,
+    "Bikes available": 1296,
+    "label": "1am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T06:30:02.000Z",
+    "Bikes in use": 153,
+    "Bikes available": 1224,
+    "label": "2am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T07:30:02.000Z",
+    "Bikes in use": 302,
+    "Bikes available": 1075,
+    "label": "3am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T08:30:02.000Z",
+    "Bikes in use": 235,
+    "Bikes available": 1142,
+    "label": "4am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T09:30:02.000Z",
+    "Bikes in use": 121,
+    "Bikes available": 1256,
+    "label": "5am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T10:30:02.000Z",
+    "Bikes in use": 110,
+    "Bikes available": 1267,
+    "label": "6am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T11:30:02.000Z",
+    "Bikes in use": 186,
+    "Bikes available": 1191,
+    "label": "7am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T12:30:02.000Z",
+    "Bikes in use": 212,
+    "Bikes available": 1165,
+    "label": "8am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T13:30:02.000Z",
+    "Bikes in use": 115,
+    "Bikes available": 1262,
+    "label": "9am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T14:30:02.000Z",
+    "Bikes in use": 117,
+    "Bikes available": 1260,
+    "label": "10am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T15:30:02.000Z",
+    "Bikes in use": 168,
+    "Bikes available": 1209,
+    "label": "11am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T16:30:02.000Z",
+    "Bikes in use": 298,
+    "Bikes available": 1079,
+    "label": "12pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T17:30:03.000Z",
+    "Bikes in use": 265,
+    "Bikes available": 1112,
+    "label": "1pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T18:30:02.000Z",
+    "Bikes in use": 150,
+    "Bikes available": 1227,
+    "label": "2pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T19:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "3pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T20:30:02.000Z",
+    "Bikes in use": 58,
+    "Bikes available": 1319,
+    "label": "4pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T21:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "5pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T22:30:02.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "6pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T23:30:02.000Z",
+    "Bikes in use": 39,
+    "Bikes available": 1338,
+    "label": "7pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T00:30:02.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "8pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T01:30:03.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "9pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T02:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "10pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T03:30:03.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "11pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T04:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "12am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T05:30:02.000Z",
+    "Bikes in use": 106,
+    "Bikes available": 1271,
+    "label": "1am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T06:30:02.000Z",
+    "Bikes in use": 187,
+    "Bikes available": 1190,
+    "label": "2am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T07:30:03.000Z",
+    "Bikes in use": 399,
+    "Bikes available": 978,
+    "label": "3am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T08:30:02.000Z",
+    "Bikes in use": 195,
+    "Bikes available": 1182,
+    "label": "4am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T09:30:02.000Z",
+    "Bikes in use": 142,
+    "Bikes available": 1235,
+    "label": "5am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T10:30:03.000Z",
+    "Bikes in use": 119,
+    "Bikes available": 1258,
+    "label": "6am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T11:30:02.000Z",
+    "Bikes in use": 174,
+    "Bikes available": 1203,
+    "label": "7am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T12:30:02.000Z",
+    "Bikes in use": 251,
+    "Bikes available": 1126,
+    "label": "8am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T13:30:03.000Z",
+    "Bikes in use": 128,
+    "Bikes available": 1249,
+    "label": "9am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T14:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "10am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T15:30:03.000Z",
+    "Bikes in use": 180,
+    "Bikes available": 1197,
+    "label": "11am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T16:30:02.000Z",
+    "Bikes in use": 355,
+    "Bikes available": 1022,
+    "label": "12pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T17:30:02.000Z",
+    "Bikes in use": 257,
+    "Bikes available": 1120,
+    "label": "1pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T18:30:02.000Z",
+    "Bikes in use": 153,
+    "Bikes available": 1224,
+    "label": "2pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T19:30:03.000Z",
+    "Bikes in use": 93,
+    "Bikes available": 1284,
+    "label": "3pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T20:30:02.000Z",
+    "Bikes in use": 65,
+    "Bikes available": 1312,
+    "label": "4pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T21:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "5pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T22:30:02.000Z",
+    "Bikes in use": 34,
+    "Bikes available": 1343,
+    "label": "6pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T23:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "7pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T00:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "8pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T01:30:02.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "9pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T02:30:03.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "10pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T03:30:02.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "11pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T04:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "12am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T05:30:02.000Z",
+    "Bikes in use": 76,
+    "Bikes available": 1301,
+    "label": "1am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T06:30:02.000Z",
+    "Bikes in use": 142,
+    "Bikes available": 1235,
+    "label": "2am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T07:30:03.000Z",
+    "Bikes in use": 409,
+    "Bikes available": 968,
+    "label": "3am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T08:30:02.000Z",
+    "Bikes in use": 210,
+    "Bikes available": 1167,
+    "label": "4am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T09:30:02.000Z",
+    "Bikes in use": 145,
+    "Bikes available": 1232,
+    "label": "5am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T10:30:02.000Z",
+    "Bikes in use": 140,
+    "Bikes available": 1237,
+    "label": "6am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T11:30:02.000Z",
+    "Bikes in use": 172,
+    "Bikes available": 1205,
+    "label": "7am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T12:30:02.000Z",
+    "Bikes in use": 203,
+    "Bikes available": 1174,
+    "label": "8am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T13:30:02.000Z",
+    "Bikes in use": 120,
+    "Bikes available": 1257,
+    "label": "9am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T14:30:02.000Z",
+    "Bikes in use": 95,
+    "Bikes available": 1282,
+    "label": "10am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T15:30:03.000Z",
+    "Bikes in use": 171,
+    "Bikes available": 1206,
+    "label": "11am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T16:30:02.000Z",
+    "Bikes in use": 335,
+    "Bikes available": 1042,
+    "label": "12pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T17:30:02.000Z",
+    "Bikes in use": 217,
+    "Bikes available": 1160,
+    "label": "1pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T18:30:02.000Z",
+    "Bikes in use": 144,
+    "Bikes available": 1233,
+    "label": "2pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T19:30:02.000Z",
+    "Bikes in use": 107,
+    "Bikes available": 1270,
+    "label": "3pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T20:30:02.000Z",
+    "Bikes in use": 79,
+    "Bikes available": 1298,
+    "label": "4pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T21:30:03.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "5pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T22:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "6pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T23:30:02.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "7pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T00:30:03.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "8pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T01:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "9pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T02:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "10pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T03:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "11pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T04:30:02.000Z",
+    "Bikes in use": 16,
+    "Bikes available": 1361,
+    "label": "12am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T05:30:02.000Z",
+    "Bikes in use": 96,
+    "Bikes available": 1281,
+    "label": "1am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T06:30:02.000Z",
+    "Bikes in use": 149,
+    "Bikes available": 1228,
+    "label": "2am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T07:30:02.000Z",
+    "Bikes in use": 419,
+    "Bikes available": 958,
+    "label": "3am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T08:30:02.000Z",
+    "Bikes in use": 239,
+    "Bikes available": 1138,
+    "label": "4am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T09:30:02.000Z",
+    "Bikes in use": 151,
+    "Bikes available": 1226,
+    "label": "5am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T10:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "6am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T11:30:03.000Z",
+    "Bikes in use": 196,
+    "Bikes available": 1181,
+    "label": "7am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T12:30:02.000Z",
+    "Bikes in use": 243,
+    "Bikes available": 1134,
+    "label": "8am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T13:30:02.000Z",
+    "Bikes in use": 98,
+    "Bikes available": 1279,
+    "label": "9am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T14:30:03.000Z",
+    "Bikes in use": 112,
+    "Bikes available": 1265,
+    "label": "10am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T15:30:02.000Z",
+    "Bikes in use": 131,
+    "Bikes available": 1246,
+    "label": "11am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T16:30:02.000Z",
+    "Bikes in use": 174,
+    "Bikes available": 1203,
+    "label": "12pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T17:30:03.000Z",
+    "Bikes in use": 229,
+    "Bikes available": 1148,
+    "label": "1pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T18:30:02.000Z",
+    "Bikes in use": 133,
+    "Bikes available": 1244,
+    "label": "2pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T19:30:02.000Z",
+    "Bikes in use": 51,
+    "Bikes available": 1326,
+    "label": "3pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T20:30:02.000Z",
+    "Bikes in use": 48,
+    "Bikes available": 1329,
+    "label": "4pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T21:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "5pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T22:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "6pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T23:30:03.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "7pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T00:30:02.000Z",
+    "Bikes in use": 2,
+    "Bikes available": 1375,
+    "label": "8pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "9pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "10pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "11pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T04:30:02.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "12am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T05:30:02.000Z",
+    "Bikes in use": 54,
+    "Bikes available": 1323,
+    "label": "1am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T06:30:02.000Z",
+    "Bikes in use": 110,
+    "Bikes available": 1267,
+    "label": "2am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T07:30:02.000Z",
+    "Bikes in use": 309,
+    "Bikes available": 1068,
+    "label": "3am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T08:30:02.000Z",
+    "Bikes in use": 136,
+    "Bikes available": 1241,
+    "label": "4am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T09:30:02.000Z",
+    "Bikes in use": 60,
+    "Bikes available": 1317,
+    "label": "5am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T10:30:02.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "6am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T11:30:02.000Z",
+    "Bikes in use": 76,
+    "Bikes available": 1301,
+    "label": "7am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T12:30:02.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "8am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T13:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "9am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T14:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "10am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T15:30:02.000Z",
+    "Bikes in use": 105,
+    "Bikes available": 1272,
+    "label": "11am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T16:30:02.000Z",
+    "Bikes in use": 115,
+    "Bikes available": 1262,
+    "label": "12pm, Friday October 25th",
     "year": "2019"
   }
 ]

--- a/public/data/Transport/dublinBikes/week.json
+++ b/public/data/Transport/dublinBikes/week.json
@@ -1,1171 +1,1185 @@
 [
   {
-    "date": "2019-09-16T03:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "3am, Monday September 16th",
+    "date": "2019-10-18T16:30:02.000Z",
+    "Bikes in use": 270,
+    "Bikes available": 1107,
+    "label": "12pm, Friday October 18th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T04:00:03.000Z",
-    "Bikes in use": 0,
-    "Bikes available": 1444,
-    "label": "4am, Monday September 16th",
+    "date": "2019-10-18T17:30:02.000Z",
+    "Bikes in use": 216,
+    "Bikes available": 1161,
+    "label": "1pm, Friday October 18th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T05:00:02.000Z",
-    "Bikes in use": 15,
-    "Bikes available": 1429,
-    "label": "5am, Monday September 16th",
+    "date": "2019-10-18T18:30:02.000Z",
+    "Bikes in use": 85,
+    "Bikes available": 1292,
+    "label": "2pm, Friday October 18th",
     "year": "2019"
   },
   {
-    "date": "2019-09-16T06:00:02.000Z",
-    "Bikes in use": 86,
-    "Bikes available": 1358,
-    "label": "6am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T07:00:02.000Z",
-    "Bikes in use": 230,
-    "Bikes available": 1214,
-    "label": "7am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T08:00:02.000Z",
-    "Bikes in use": 319,
-    "Bikes available": 1125,
-    "label": "8am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T09:00:02.000Z",
-    "Bikes in use": 157,
-    "Bikes available": 1287,
-    "label": "9am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T10:00:02.000Z",
-    "Bikes in use": 166,
-    "Bikes available": 1278,
-    "label": "10am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T11:00:02.000Z",
-    "Bikes in use": 127,
-    "Bikes available": 1317,
-    "label": "11am, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T12:00:02.000Z",
-    "Bikes in use": 178,
-    "Bikes available": 1266,
-    "label": "12pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T13:00:02.000Z",
-    "Bikes in use": 163,
-    "Bikes available": 1281,
-    "label": "1pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T14:00:03.000Z",
-    "Bikes in use": 110,
-    "Bikes available": 1334,
-    "label": "2pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T15:00:03.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1345,
-    "label": "3pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T16:00:03.000Z",
-    "Bikes in use": 278,
-    "Bikes available": 1166,
-    "label": "4pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T17:00:02.000Z",
-    "Bikes in use": 354,
-    "Bikes available": 1090,
-    "label": "5pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T18:00:02.000Z",
-    "Bikes in use": 213,
-    "Bikes available": 1231,
-    "label": "6pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T19:00:03.000Z",
-    "Bikes in use": 175,
-    "Bikes available": 1269,
-    "label": "7pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T20:00:02.000Z",
-    "Bikes in use": 104,
-    "Bikes available": 1340,
-    "label": "8pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T21:00:03.000Z",
-    "Bikes in use": 54,
-    "Bikes available": 1390,
-    "label": "9pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T22:00:02.000Z",
-    "Bikes in use": 61,
-    "Bikes available": 1383,
-    "label": "10pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-16T23:00:03.000Z",
-    "Bikes in use": 45,
-    "Bikes available": 1399,
-    "label": "11pm, Monday September 16th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T00:00:02.000Z",
-    "Bikes in use": 33,
-    "Bikes available": 1411,
-    "label": "12am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T01:00:02.000Z",
-    "Bikes in use": 31,
-    "Bikes available": 1413,
-    "label": "1am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T02:00:02.000Z",
-    "Bikes in use": 31,
-    "Bikes available": 1413,
-    "label": "2am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T03:00:03.000Z",
-    "Bikes in use": 30,
-    "Bikes available": 1414,
-    "label": "3am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T04:00:02.000Z",
-    "Bikes in use": 30,
-    "Bikes available": 1414,
-    "label": "4am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T05:00:02.000Z",
-    "Bikes in use": 75,
-    "Bikes available": 1369,
-    "label": "5am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T06:00:02.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1345,
-    "label": "6am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T07:00:03.000Z",
-    "Bikes in use": 297,
-    "Bikes available": 1147,
-    "label": "7am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T08:00:02.000Z",
-    "Bikes in use": 395,
-    "Bikes available": 1049,
-    "label": "8am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T09:00:02.000Z",
-    "Bikes in use": 156,
-    "Bikes available": 1288,
-    "label": "9am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T10:00:02.000Z",
-    "Bikes in use": 117,
-    "Bikes available": 1327,
-    "label": "10am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T11:00:02.000Z",
-    "Bikes in use": 125,
-    "Bikes available": 1319,
-    "label": "11am, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T12:00:02.000Z",
-    "Bikes in use": 220,
-    "Bikes available": 1224,
-    "label": "12pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T13:00:03.000Z",
-    "Bikes in use": 204,
-    "Bikes available": 1240,
-    "label": "1pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T14:00:03.000Z",
-    "Bikes in use": 114,
-    "Bikes available": 1330,
-    "label": "2pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T15:00:03.000Z",
-    "Bikes in use": 139,
-    "Bikes available": 1305,
-    "label": "3pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T17:00:02.000Z",
-    "Bikes in use": 377,
-    "Bikes available": 1067,
-    "label": "5pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T18:00:03.000Z",
-    "Bikes in use": 226,
-    "Bikes available": 1218,
-    "label": "6pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T19:00:03.000Z",
-    "Bikes in use": 155,
-    "Bikes available": 1289,
-    "label": "7pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T20:00:03.000Z",
-    "Bikes in use": 99,
-    "Bikes available": 1345,
-    "label": "8pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T21:00:02.000Z",
-    "Bikes in use": 67,
-    "Bikes available": 1377,
-    "label": "9pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T22:00:03.000Z",
-    "Bikes in use": 47,
-    "Bikes available": 1397,
-    "label": "10pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-17T23:00:02.000Z",
-    "Bikes in use": 47,
-    "Bikes available": 1397,
-    "label": "11pm, Tuesday September 17th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T00:00:02.000Z",
-    "Bikes in use": 36,
-    "Bikes available": 1408,
-    "label": "12am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T01:00:02.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1410,
-    "label": "1am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T02:00:02.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1410,
-    "label": "2am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T03:00:03.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1410,
-    "label": "3am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T04:00:03.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1410,
-    "label": "4am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T05:00:02.000Z",
-    "Bikes in use": 36,
-    "Bikes available": 1408,
-    "label": "5am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T06:00:02.000Z",
-    "Bikes in use": 120,
-    "Bikes available": 1324,
-    "label": "6am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T07:00:02.000Z",
-    "Bikes in use": 329,
-    "Bikes available": 1115,
-    "label": "7am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T08:00:02.000Z",
-    "Bikes in use": 441,
-    "Bikes available": 1003,
-    "label": "8am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T09:00:02.000Z",
-    "Bikes in use": 215,
-    "Bikes available": 1229,
-    "label": "9am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T10:00:02.000Z",
-    "Bikes in use": 191,
-    "Bikes available": 1253,
-    "label": "10am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T11:00:03.000Z",
-    "Bikes in use": 144,
-    "Bikes available": 1300,
-    "label": "11am, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T12:00:02.000Z",
-    "Bikes in use": 259,
-    "Bikes available": 1185,
-    "label": "12pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T13:00:03.000Z",
-    "Bikes in use": 211,
-    "Bikes available": 1233,
-    "label": "1pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T14:00:02.000Z",
-    "Bikes in use": 160,
-    "Bikes available": 1284,
-    "label": "2pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T15:00:02.000Z",
-    "Bikes in use": 172,
-    "Bikes available": 1272,
-    "label": "3pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T16:00:02.000Z",
-    "Bikes in use": 355,
-    "Bikes available": 1089,
-    "label": "4pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T17:00:03.000Z",
-    "Bikes in use": 391,
-    "Bikes available": 1053,
-    "label": "5pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T18:00:03.000Z",
-    "Bikes in use": 271,
-    "Bikes available": 1173,
-    "label": "6pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T19:00:03.000Z",
-    "Bikes in use": 205,
-    "Bikes available": 1239,
-    "label": "7pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T20:00:02.000Z",
-    "Bikes in use": 128,
-    "Bikes available": 1316,
-    "label": "8pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T21:00:03.000Z",
-    "Bikes in use": 110,
-    "Bikes available": 1334,
-    "label": "9pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T22:00:03.000Z",
-    "Bikes in use": 77,
-    "Bikes available": 1367,
-    "label": "10pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-18T23:00:02.000Z",
-    "Bikes in use": 60,
-    "Bikes available": 1384,
-    "label": "11pm, Wednesday September 18th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T00:00:03.000Z",
-    "Bikes in use": 42,
-    "Bikes available": 1402,
-    "label": "12am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T01:00:03.000Z",
-    "Bikes in use": 42,
-    "Bikes available": 1402,
-    "label": "1am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T02:00:03.000Z",
-    "Bikes in use": 42,
-    "Bikes available": 1402,
-    "label": "2am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T03:00:02.000Z",
-    "Bikes in use": 42,
-    "Bikes available": 1402,
-    "label": "3am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T04:00:03.000Z",
-    "Bikes in use": 42,
-    "Bikes available": 1402,
-    "label": "4am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T05:00:02.000Z",
-    "Bikes in use": 79,
-    "Bikes available": 1365,
-    "label": "5am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T06:00:02.000Z",
-    "Bikes in use": 156,
-    "Bikes available": 1288,
-    "label": "6am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T07:00:03.000Z",
-    "Bikes in use": 296,
-    "Bikes available": 1148,
-    "label": "7am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T08:00:02.000Z",
-    "Bikes in use": 482,
-    "Bikes available": 962,
-    "label": "8am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T09:00:02.000Z",
-    "Bikes in use": 198,
-    "Bikes available": 1246,
-    "label": "9am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T10:00:02.000Z",
-    "Bikes in use": 188,
-    "Bikes available": 1256,
-    "label": "10am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T11:00:02.000Z",
-    "Bikes in use": 157,
-    "Bikes available": 1287,
-    "label": "11am, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T12:00:03.000Z",
-    "Bikes in use": 280,
-    "Bikes available": 1164,
-    "label": "12pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T13:00:02.000Z",
-    "Bikes in use": 234,
-    "Bikes available": 1210,
-    "label": "1pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T14:00:02.000Z",
-    "Bikes in use": 118,
-    "Bikes available": 1326,
-    "label": "2pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T15:00:02.000Z",
-    "Bikes in use": 133,
+    "date": "2019-10-18T19:30:02.000Z",
+    "Bikes in use": 66,
     "Bikes available": 1311,
-    "label": "3pm, Thursday September 19th",
+    "label": "3pm, Friday October 18th",
     "year": "2019"
   },
   {
-    "date": "2019-09-19T16:00:02.000Z",
-    "Bikes in use": 332,
-    "Bikes available": 1112,
-    "label": "4pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T17:00:03.000Z",
-    "Bikes in use": 400,
-    "Bikes available": 1044,
-    "label": "5pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T18:00:02.000Z",
-    "Bikes in use": 229,
-    "Bikes available": 1215,
-    "label": "6pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T19:00:02.000Z",
-    "Bikes in use": 133,
-    "Bikes available": 1311,
-    "label": "7pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T20:00:02.000Z",
-    "Bikes in use": 87,
-    "Bikes available": 1357,
-    "label": "8pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T21:00:03.000Z",
-    "Bikes in use": 76,
-    "Bikes available": 1368,
-    "label": "9pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T22:00:03.000Z",
-    "Bikes in use": 31,
-    "Bikes available": 1413,
-    "label": "10pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-19T23:00:02.000Z",
-    "Bikes in use": 30,
-    "Bikes available": 1414,
-    "label": "11pm, Thursday September 19th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T00:00:03.000Z",
-    "Bikes in use": 21,
-    "Bikes available": 1423,
-    "label": "12am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T01:00:02.000Z",
-    "Bikes in use": 20,
-    "Bikes available": 1424,
-    "label": "1am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T02:00:02.000Z",
-    "Bikes in use": 20,
-    "Bikes available": 1424,
-    "label": "2am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T03:00:03.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1425,
-    "label": "3am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T04:00:03.000Z",
-    "Bikes in use": 18,
-    "Bikes available": 1426,
-    "label": "4am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T05:00:02.000Z",
-    "Bikes in use": 53,
-    "Bikes available": 1391,
-    "label": "5am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T06:00:02.000Z",
-    "Bikes in use": 111,
-    "Bikes available": 1333,
-    "label": "6am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T07:00:02.000Z",
-    "Bikes in use": 291,
-    "Bikes available": 1153,
-    "label": "7am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T08:00:03.000Z",
-    "Bikes in use": 394,
-    "Bikes available": 1050,
-    "label": "8am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T09:00:02.000Z",
-    "Bikes in use": 199,
-    "Bikes available": 1245,
-    "label": "9am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T10:00:02.000Z",
-    "Bikes in use": 127,
-    "Bikes available": 1317,
-    "label": "10am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T11:00:03.000Z",
-    "Bikes in use": 161,
-    "Bikes available": 1283,
-    "label": "11am, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T12:00:02.000Z",
-    "Bikes in use": 276,
-    "Bikes available": 1168,
-    "label": "12pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T13:00:02.000Z",
-    "Bikes in use": 233,
-    "Bikes available": 1211,
-    "label": "1pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T14:00:02.000Z",
-    "Bikes in use": 138,
-    "Bikes available": 1306,
-    "label": "2pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T15:00:02.000Z",
-    "Bikes in use": 241,
-    "Bikes available": 1203,
-    "label": "3pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T16:00:02.000Z",
-    "Bikes in use": 354,
-    "Bikes available": 1090,
-    "label": "4pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T17:00:02.000Z",
-    "Bikes in use": 354,
-    "Bikes available": 1090,
-    "label": "5pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T18:00:03.000Z",
-    "Bikes in use": 214,
-    "Bikes available": 1230,
-    "label": "6pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T19:00:02.000Z",
-    "Bikes in use": 163,
-    "Bikes available": 1281,
-    "label": "7pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T20:00:03.000Z",
-    "Bikes in use": 113,
-    "Bikes available": 1331,
-    "label": "8pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T21:00:02.000Z",
-    "Bikes in use": 125,
-    "Bikes available": 1319,
-    "label": "9pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T22:00:02.000Z",
-    "Bikes in use": 86,
-    "Bikes available": 1358,
-    "label": "10pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-20T23:00:02.000Z",
-    "Bikes in use": 68,
-    "Bikes available": 1376,
-    "label": "11pm, Friday September 20th",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T00:00:03.000Z",
-    "Bikes in use": 25,
-    "Bikes available": 1419,
-    "label": "12am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T01:00:03.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1425,
-    "label": "1am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T02:00:02.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1425,
-    "label": "2am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T03:00:03.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1425,
-    "label": "3am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T04:00:02.000Z",
-    "Bikes in use": 19,
-    "Bikes available": 1425,
-    "label": "4am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T05:00:02.000Z",
-    "Bikes in use": 28,
-    "Bikes available": 1416,
-    "label": "5am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T06:00:03.000Z",
-    "Bikes in use": 33,
-    "Bikes available": 1411,
-    "label": "6am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T07:00:03.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1410,
-    "label": "7am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T08:00:03.000Z",
-    "Bikes in use": 77,
-    "Bikes available": 1367,
-    "label": "8am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T09:00:02.000Z",
-    "Bikes in use": 106,
-    "Bikes available": 1338,
-    "label": "9am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T10:00:02.000Z",
-    "Bikes in use": 154,
-    "Bikes available": 1290,
-    "label": "10am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T11:00:02.000Z",
-    "Bikes in use": 175,
-    "Bikes available": 1269,
-    "label": "11am, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T12:00:02.000Z",
-    "Bikes in use": 220,
-    "Bikes available": 1224,
-    "label": "12pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T13:00:03.000Z",
-    "Bikes in use": 185,
-    "Bikes available": 1259,
-    "label": "1pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T14:00:02.000Z",
-    "Bikes in use": 188,
-    "Bikes available": 1256,
-    "label": "2pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T15:00:03.000Z",
-    "Bikes in use": 185,
-    "Bikes available": 1259,
-    "label": "3pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T16:00:02.000Z",
-    "Bikes in use": 174,
-    "Bikes available": 1270,
-    "label": "4pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T17:00:02.000Z",
-    "Bikes in use": 132,
-    "Bikes available": 1312,
-    "label": "5pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T18:00:03.000Z",
-    "Bikes in use": 75,
-    "Bikes available": 1369,
-    "label": "6pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T19:00:28.000Z",
-    "Bikes in use": 81,
-    "Bikes available": 1363,
-    "label": "7pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T20:00:02.000Z",
-    "Bikes in use": 65,
-    "Bikes available": 1379,
-    "label": "8pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T21:00:02.000Z",
-    "Bikes in use": 58,
-    "Bikes available": 1386,
-    "label": "9pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T22:00:02.000Z",
-    "Bikes in use": 57,
-    "Bikes available": 1387,
-    "label": "10pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-21T23:00:02.000Z",
-    "Bikes in use": 67,
-    "Bikes available": 1377,
-    "label": "11pm, Saturday September 21st",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T00:00:03.000Z",
-    "Bikes in use": 39,
-    "Bikes available": 1405,
-    "label": "12am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T01:00:02.000Z",
-    "Bikes in use": 30,
-    "Bikes available": 1414,
-    "label": "1am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T02:00:02.000Z",
-    "Bikes in use": 26,
-    "Bikes available": 1418,
-    "label": "2am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T03:00:03.000Z",
-    "Bikes in use": 25,
-    "Bikes available": 1419,
-    "label": "3am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T04:00:02.000Z",
-    "Bikes in use": 25,
-    "Bikes available": 1419,
-    "label": "4am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T05:00:02.000Z",
-    "Bikes in use": 29,
-    "Bikes available": 1415,
-    "label": "5am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T06:00:02.000Z",
-    "Bikes in use": 26,
-    "Bikes available": 1418,
-    "label": "6am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T07:00:02.000Z",
-    "Bikes in use": 29,
-    "Bikes available": 1415,
-    "label": "7am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T08:00:03.000Z",
-    "Bikes in use": 37,
-    "Bikes available": 1407,
-    "label": "8am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T09:00:03.000Z",
-    "Bikes in use": 44,
-    "Bikes available": 1400,
-    "label": "9am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T10:00:03.000Z",
-    "Bikes in use": 77,
-    "Bikes available": 1367,
-    "label": "10am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T11:00:03.000Z",
-    "Bikes in use": 88,
-    "Bikes available": 1356,
-    "label": "11am, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T12:00:03.000Z",
-    "Bikes in use": 102,
-    "Bikes available": 1342,
-    "label": "12pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T13:00:03.000Z",
-    "Bikes in use": 123,
-    "Bikes available": 1321,
-    "label": "1pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T14:00:02.000Z",
-    "Bikes in use": 111,
-    "Bikes available": 1333,
-    "label": "2pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T15:00:02.000Z",
-    "Bikes in use": 136,
-    "Bikes available": 1308,
-    "label": "3pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T16:00:02.000Z",
-    "Bikes in use": 119,
-    "Bikes available": 1325,
-    "label": "4pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T17:00:02.000Z",
-    "Bikes in use": 123,
-    "Bikes available": 1321,
-    "label": "5pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T18:00:03.000Z",
-    "Bikes in use": 80,
-    "Bikes available": 1364,
-    "label": "6pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T19:00:02.000Z",
-    "Bikes in use": 35,
-    "Bikes available": 1409,
-    "label": "7pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T20:00:02.000Z",
-    "Bikes in use": 46,
-    "Bikes available": 1398,
-    "label": "8pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T21:00:03.000Z",
-    "Bikes in use": 48,
-    "Bikes available": 1396,
-    "label": "9pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T22:00:03.000Z",
-    "Bikes in use": 34,
-    "Bikes available": 1410,
-    "label": "10pm, Sunday September 22nd",
-    "year": "2019"
-  },
-  {
-    "date": "2019-09-22T23:00:02.000Z",
+    "date": "2019-10-18T20:30:03.000Z",
     "Bikes in use": 42,
-    "Bikes available": 1402,
-    "label": "11pm, Sunday September 22nd",
+    "Bikes available": 1335,
+    "label": "4pm, Friday October 18th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T00:00:03.000Z",
+    "date": "2019-10-18T21:30:02.000Z",
     "Bikes in use": 32,
-    "Bikes available": 1412,
-    "label": "12am, Monday September 23rd",
+    "Bikes available": 1345,
+    "label": "5pm, Friday October 18th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T01:00:03.000Z",
-    "Bikes in use": 30,
-    "Bikes available": 1414,
-    "label": "1am, Monday September 23rd",
+    "date": "2019-10-18T22:30:03.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "6pm, Friday October 18th",
     "year": "2019"
   },
   {
-    "date": "2019-09-23T02:00:02.000Z",
+    "date": "2019-10-18T23:30:02.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "7pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T00:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1378,
+    "label": "8pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T01:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1381,
+    "label": "9pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T02:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1381,
+    "label": "10pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1381,
+    "label": "11pm, Friday October 18th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T04:30:03.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1378,
+    "label": "12am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T05:30:02.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "1am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T06:30:02.000Z",
+    "Bikes in use": 25,
+    "Bikes available": 1352,
+    "label": "2am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T07:30:03.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "3am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T08:30:02.000Z",
+    "Bikes in use": 34,
+    "Bikes available": 1343,
+    "label": "4am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T09:30:02.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "5am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T10:30:27.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "6am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T11:30:02.000Z",
+    "Bikes in use": 68,
+    "Bikes available": 1309,
+    "label": "7am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T12:30:02.000Z",
+    "Bikes in use": 62,
+    "Bikes available": 1315,
+    "label": "8am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T13:30:03.000Z",
+    "Bikes in use": 82,
+    "Bikes available": 1295,
+    "label": "9am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T14:30:03.000Z",
+    "Bikes in use": 111,
+    "Bikes available": 1266,
+    "label": "10am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T15:30:02.000Z",
+    "Bikes in use": 75,
+    "Bikes available": 1302,
+    "label": "11am, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T16:30:03.000Z",
+    "Bikes in use": 105,
+    "Bikes available": 1272,
+    "label": "12pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T17:30:02.000Z",
+    "Bikes in use": 82,
+    "Bikes available": 1295,
+    "label": "1pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T18:30:02.000Z",
+    "Bikes in use": 75,
+    "Bikes available": 1302,
+    "label": "2pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T19:30:02.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "3pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T20:30:02.000Z",
+    "Bikes in use": 52,
+    "Bikes available": 1325,
+    "label": "4pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T21:30:02.000Z",
+    "Bikes in use": 48,
+    "Bikes available": 1329,
+    "label": "5pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T22:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "6pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-19T23:30:27.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "7pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T00:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "8pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T01:30:02.000Z",
+    "Bikes in use": 19,
+    "Bikes available": 1358,
+    "label": "9pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T02:30:02.000Z",
+    "Bikes in use": 16,
+    "Bikes available": 1361,
+    "label": "10pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T03:30:02.000Z",
+    "Bikes in use": 14,
+    "Bikes available": 1363,
+    "label": "11pm, Saturday October 19th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T04:30:02.000Z",
+    "Bikes in use": 16,
+    "Bikes available": 1361,
+    "label": "12am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T05:30:02.000Z",
+    "Bikes in use": 25,
+    "Bikes available": 1352,
+    "label": "1am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T06:30:02.000Z",
     "Bikes in use": 29,
-    "Bikes available": 1415,
-    "label": "2am, Monday September 23rd",
+    "Bikes available": 1348,
+    "label": "2am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T07:30:03.000Z",
+    "Bikes in use": 47,
+    "Bikes available": 1330,
+    "label": "3am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T08:30:02.000Z",
+    "Bikes in use": 39,
+    "Bikes available": 1338,
+    "label": "4am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T09:30:03.000Z",
+    "Bikes in use": 69,
+    "Bikes available": 1308,
+    "label": "5am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T10:30:02.000Z",
+    "Bikes in use": 83,
+    "Bikes available": 1294,
+    "label": "6am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T11:30:02.000Z",
+    "Bikes in use": 106,
+    "Bikes available": 1271,
+    "label": "7am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T12:30:02.000Z",
+    "Bikes in use": 128,
+    "Bikes available": 1249,
+    "label": "8am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T13:30:03.000Z",
+    "Bikes in use": 152,
+    "Bikes available": 1225,
+    "label": "9am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T14:30:02.000Z",
+    "Bikes in use": 162,
+    "Bikes available": 1215,
+    "label": "10am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T15:30:02.000Z",
+    "Bikes in use": 136,
+    "Bikes available": 1241,
+    "label": "11am, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T16:30:03.000Z",
+    "Bikes in use": 112,
+    "Bikes available": 1265,
+    "label": "12pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T17:30:02.000Z",
+    "Bikes in use": 87,
+    "Bikes available": 1290,
+    "label": "1pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T18:30:02.000Z",
+    "Bikes in use": 65,
+    "Bikes available": 1312,
+    "label": "2pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T19:30:03.000Z",
+    "Bikes in use": 64,
+    "Bikes available": 1313,
+    "label": "3pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T20:30:02.000Z",
+    "Bikes in use": 47,
+    "Bikes available": 1330,
+    "label": "4pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T21:30:02.000Z",
+    "Bikes in use": 40,
+    "Bikes available": 1337,
+    "label": "5pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T22:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "6pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-20T23:30:03.000Z",
+    "Bikes in use": 25,
+    "Bikes available": 1352,
+    "label": "7pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T00:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "8pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T01:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "9pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T02:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "10pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T03:30:02.000Z",
+    "Bikes in use": 24,
+    "Bikes available": 1353,
+    "label": "11pm, Sunday October 20th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T04:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "12am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T05:30:02.000Z",
+    "Bikes in use": 81,
+    "Bikes available": 1296,
+    "label": "1am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T06:30:02.000Z",
+    "Bikes in use": 153,
+    "Bikes available": 1224,
+    "label": "2am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T07:30:02.000Z",
+    "Bikes in use": 302,
+    "Bikes available": 1075,
+    "label": "3am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T08:30:02.000Z",
+    "Bikes in use": 235,
+    "Bikes available": 1142,
+    "label": "4am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T09:30:02.000Z",
+    "Bikes in use": 121,
+    "Bikes available": 1256,
+    "label": "5am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T10:30:02.000Z",
+    "Bikes in use": 110,
+    "Bikes available": 1267,
+    "label": "6am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T11:30:02.000Z",
+    "Bikes in use": 186,
+    "Bikes available": 1191,
+    "label": "7am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T12:30:02.000Z",
+    "Bikes in use": 212,
+    "Bikes available": 1165,
+    "label": "8am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T13:30:02.000Z",
+    "Bikes in use": 115,
+    "Bikes available": 1262,
+    "label": "9am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T14:30:02.000Z",
+    "Bikes in use": 117,
+    "Bikes available": 1260,
+    "label": "10am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T15:30:02.000Z",
+    "Bikes in use": 168,
+    "Bikes available": 1209,
+    "label": "11am, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T16:30:02.000Z",
+    "Bikes in use": 298,
+    "Bikes available": 1079,
+    "label": "12pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T17:30:03.000Z",
+    "Bikes in use": 265,
+    "Bikes available": 1112,
+    "label": "1pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T18:30:02.000Z",
+    "Bikes in use": 150,
+    "Bikes available": 1227,
+    "label": "2pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T19:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "3pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T20:30:02.000Z",
+    "Bikes in use": 58,
+    "Bikes available": 1319,
+    "label": "4pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T21:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "5pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T22:30:02.000Z",
+    "Bikes in use": 28,
+    "Bikes available": 1349,
+    "label": "6pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-21T23:30:02.000Z",
+    "Bikes in use": 39,
+    "Bikes available": 1338,
+    "label": "7pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T00:30:02.000Z",
+    "Bikes in use": 27,
+    "Bikes available": 1350,
+    "label": "8pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T01:30:03.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "9pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T02:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "10pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T03:30:03.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "11pm, Monday October 21st",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T04:30:02.000Z",
+    "Bikes in use": 35,
+    "Bikes available": 1342,
+    "label": "12am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T05:30:02.000Z",
+    "Bikes in use": 106,
+    "Bikes available": 1271,
+    "label": "1am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T06:30:02.000Z",
+    "Bikes in use": 187,
+    "Bikes available": 1190,
+    "label": "2am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T07:30:03.000Z",
+    "Bikes in use": 399,
+    "Bikes available": 978,
+    "label": "3am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T08:30:02.000Z",
+    "Bikes in use": 195,
+    "Bikes available": 1182,
+    "label": "4am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T09:30:02.000Z",
+    "Bikes in use": 142,
+    "Bikes available": 1235,
+    "label": "5am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T10:30:03.000Z",
+    "Bikes in use": 119,
+    "Bikes available": 1258,
+    "label": "6am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T11:30:02.000Z",
+    "Bikes in use": 174,
+    "Bikes available": 1203,
+    "label": "7am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T12:30:02.000Z",
+    "Bikes in use": 251,
+    "Bikes available": 1126,
+    "label": "8am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T13:30:03.000Z",
+    "Bikes in use": 128,
+    "Bikes available": 1249,
+    "label": "9am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T14:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "10am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T15:30:03.000Z",
+    "Bikes in use": 180,
+    "Bikes available": 1197,
+    "label": "11am, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T16:30:02.000Z",
+    "Bikes in use": 355,
+    "Bikes available": 1022,
+    "label": "12pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T17:30:02.000Z",
+    "Bikes in use": 257,
+    "Bikes available": 1120,
+    "label": "1pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T18:30:02.000Z",
+    "Bikes in use": 153,
+    "Bikes available": 1224,
+    "label": "2pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T19:30:03.000Z",
+    "Bikes in use": 93,
+    "Bikes available": 1284,
+    "label": "3pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T20:30:02.000Z",
+    "Bikes in use": 65,
+    "Bikes available": 1312,
+    "label": "4pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T21:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "5pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T22:30:02.000Z",
+    "Bikes in use": 34,
+    "Bikes available": 1343,
+    "label": "6pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-22T23:30:02.000Z",
+    "Bikes in use": 26,
+    "Bikes available": 1351,
+    "label": "7pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T00:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "8pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T01:30:02.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "9pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T02:30:03.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "10pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T03:30:02.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "11pm, Tuesday October 22nd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T04:30:02.000Z",
+    "Bikes in use": 12,
+    "Bikes available": 1365,
+    "label": "12am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T05:30:02.000Z",
+    "Bikes in use": 76,
+    "Bikes available": 1301,
+    "label": "1am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T06:30:02.000Z",
+    "Bikes in use": 142,
+    "Bikes available": 1235,
+    "label": "2am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T07:30:03.000Z",
+    "Bikes in use": 409,
+    "Bikes available": 968,
+    "label": "3am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T08:30:02.000Z",
+    "Bikes in use": 210,
+    "Bikes available": 1167,
+    "label": "4am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T09:30:02.000Z",
+    "Bikes in use": 145,
+    "Bikes available": 1232,
+    "label": "5am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T10:30:02.000Z",
+    "Bikes in use": 140,
+    "Bikes available": 1237,
+    "label": "6am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T11:30:02.000Z",
+    "Bikes in use": 172,
+    "Bikes available": 1205,
+    "label": "7am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T12:30:02.000Z",
+    "Bikes in use": 203,
+    "Bikes available": 1174,
+    "label": "8am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T13:30:02.000Z",
+    "Bikes in use": 120,
+    "Bikes available": 1257,
+    "label": "9am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T14:30:02.000Z",
+    "Bikes in use": 95,
+    "Bikes available": 1282,
+    "label": "10am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T15:30:03.000Z",
+    "Bikes in use": 171,
+    "Bikes available": 1206,
+    "label": "11am, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T16:30:02.000Z",
+    "Bikes in use": 335,
+    "Bikes available": 1042,
+    "label": "12pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T17:30:02.000Z",
+    "Bikes in use": 217,
+    "Bikes available": 1160,
+    "label": "1pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T18:30:02.000Z",
+    "Bikes in use": 144,
+    "Bikes available": 1233,
+    "label": "2pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T19:30:02.000Z",
+    "Bikes in use": 107,
+    "Bikes available": 1270,
+    "label": "3pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T20:30:02.000Z",
+    "Bikes in use": 79,
+    "Bikes available": 1298,
+    "label": "4pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T21:30:03.000Z",
+    "Bikes in use": 50,
+    "Bikes available": 1327,
+    "label": "5pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T22:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "6pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-23T23:30:02.000Z",
+    "Bikes in use": 20,
+    "Bikes available": 1357,
+    "label": "7pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T00:30:03.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "8pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T01:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "9pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T02:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "10pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T03:30:02.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "11pm, Wednesday October 23rd",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T04:30:02.000Z",
+    "Bikes in use": 16,
+    "Bikes available": 1361,
+    "label": "12am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T05:30:02.000Z",
+    "Bikes in use": 96,
+    "Bikes available": 1281,
+    "label": "1am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T06:30:02.000Z",
+    "Bikes in use": 149,
+    "Bikes available": 1228,
+    "label": "2am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T07:30:02.000Z",
+    "Bikes in use": 419,
+    "Bikes available": 958,
+    "label": "3am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T08:30:02.000Z",
+    "Bikes in use": 239,
+    "Bikes available": 1138,
+    "label": "4am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T09:30:02.000Z",
+    "Bikes in use": 151,
+    "Bikes available": 1226,
+    "label": "5am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T10:30:02.000Z",
+    "Bikes in use": 108,
+    "Bikes available": 1269,
+    "label": "6am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T11:30:03.000Z",
+    "Bikes in use": 196,
+    "Bikes available": 1181,
+    "label": "7am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T12:30:02.000Z",
+    "Bikes in use": 243,
+    "Bikes available": 1134,
+    "label": "8am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T13:30:02.000Z",
+    "Bikes in use": 98,
+    "Bikes available": 1279,
+    "label": "9am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T14:30:03.000Z",
+    "Bikes in use": 112,
+    "Bikes available": 1265,
+    "label": "10am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T15:30:02.000Z",
+    "Bikes in use": 131,
+    "Bikes available": 1246,
+    "label": "11am, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T16:30:02.000Z",
+    "Bikes in use": 174,
+    "Bikes available": 1203,
+    "label": "12pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T17:30:03.000Z",
+    "Bikes in use": 229,
+    "Bikes available": 1148,
+    "label": "1pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T18:30:02.000Z",
+    "Bikes in use": 133,
+    "Bikes available": 1244,
+    "label": "2pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T19:30:02.000Z",
+    "Bikes in use": 51,
+    "Bikes available": 1326,
+    "label": "3pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T20:30:02.000Z",
+    "Bikes in use": 48,
+    "Bikes available": 1329,
+    "label": "4pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T21:30:02.000Z",
+    "Bikes in use": 38,
+    "Bikes available": 1339,
+    "label": "5pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T22:30:02.000Z",
+    "Bikes in use": 21,
+    "Bikes available": 1356,
+    "label": "6pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-24T23:30:03.000Z",
+    "Bikes in use": 15,
+    "Bikes available": 1362,
+    "label": "7pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T00:30:02.000Z",
+    "Bikes in use": 2,
+    "Bikes available": 1375,
+    "label": "8pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T01:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "9pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T02:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "10pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T03:30:02.000Z",
+    "Bikes in use": 0,
+    "Bikes available": 1377,
+    "label": "11pm, Thursday October 24th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T04:30:02.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "12am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T05:30:02.000Z",
+    "Bikes in use": 54,
+    "Bikes available": 1323,
+    "label": "1am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T06:30:02.000Z",
+    "Bikes in use": 110,
+    "Bikes available": 1267,
+    "label": "2am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T07:30:02.000Z",
+    "Bikes in use": 309,
+    "Bikes available": 1068,
+    "label": "3am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T08:30:02.000Z",
+    "Bikes in use": 136,
+    "Bikes available": 1241,
+    "label": "4am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T09:30:02.000Z",
+    "Bikes in use": 60,
+    "Bikes available": 1317,
+    "label": "5am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T10:30:02.000Z",
+    "Bikes in use": 46,
+    "Bikes available": 1331,
+    "label": "6am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T11:30:02.000Z",
+    "Bikes in use": 76,
+    "Bikes available": 1301,
+    "label": "7am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T12:30:02.000Z",
+    "Bikes in use": 42,
+    "Bikes available": 1335,
+    "label": "8am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T13:30:02.000Z",
+    "Bikes in use": 29,
+    "Bikes available": 1348,
+    "label": "9am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T14:30:02.000Z",
+    "Bikes in use": 11,
+    "Bikes available": 1366,
+    "label": "10am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T15:30:02.000Z",
+    "Bikes in use": 105,
+    "Bikes available": 1272,
+    "label": "11am, Friday October 25th",
+    "year": "2019"
+  },
+  {
+    "date": "2019-10-25T16:30:02.000Z",
+    "Bikes in use": 115,
+    "Bikes available": 1262,
+    "label": "12pm, Friday October 25th",
     "year": "2019"
   }
 ]

--- a/public/javascripts/themes/transport/transport_dublinbikes.js
+++ b/public/javascripts/themes/transport/transport_dublinbikes.js
@@ -97,7 +97,7 @@ Promise.all([
       dublinBikesChart.drawChart();
       //dublinBikesChart.updateChart();
       dublinBikesChart.addTooltip("Dublin Bikes at ", "thousands", "label", "", "");
-
+      updateTextInfo(dataDay);
     });
 
     d3.select("#dublinbikes_week").on("click", function() {
@@ -106,7 +106,7 @@ Promise.all([
       dublinBikesChart.drawChart();
       //dublinBikesChart.updateChart();
       dublinBikesChart.addTooltip("Dublin Bikes at ", "thousands", "label", "", "");
-
+      updateTextInfo(dataWeek);
     });
 
     d3.select("#dublinbikes_month").on("click", function() {
@@ -115,7 +115,7 @@ Promise.all([
       dublinBikesChart.drawChart();
       //dublinBikesChart.updateChart();
       dublinBikesChart.addTooltip("Dublin Bikes at ", "thousands", "label", "", "");
-
+      updateTextInfo(dataMonth);
     });
 
   }).catch(function(error) {
@@ -166,9 +166,19 @@ function updateTextInfo(data) {
   //console.log("Bikes data " + JSON.stringify(data) + "\n");
   let peakUse = getMax(data, "Bikes in use");
   d3.select('#bikes-in-use-count').text(peakUse["Bikes in use"]);
-  d3.select('#max-bikes-use-time').text(peakUse["label"].split(',')[0]);
+  d3.select('#max-bikes-use-time').text(peakUse["label"]);//.split(',')[0]);
   d3.select('#bikes-available').text(peakUse["Bikes available"]);
   // d3.select('#stands-count').html(bikeStands);
+  let currentBikes = data[data.length-1]["Bikes in use"];
+  let timePeriod = getTimePeriod(data);
+  let percentChange = getPercentChange(data, "Bikes in use");
+  let previousTime = getPreviousTime(data);
+  d3.select('#current-bikes-in-use-count').text(currentBikes);
+  d3.select('#time-period').text(timePeriod);
+  d3.select('#percent-change-with-indicator').text(indicatorText(percentChange.toPrecision(2))); 
+  setIndicatorColour(percentChange, "#percent-change-with-indicator");
+  d3.select('#previous-time').text(previousTime);
+
 
   // console.log("Bike Station: \n" + JSON.stringify(data_[0].name));
   // console.log("# of bike stations is " + data_.length + "\n");
@@ -180,4 +190,84 @@ function getMax(data, p) {
   });
   console.log("Bikes info " + JSON.stringify(max));
   return max;
+};
+
+//ars are array and property to be evaluated as a string
+function getPercentChange(data, p) {
+  let percent = 0; //default is no change
+  if (data[0][p] >0 ) {
+	
+	//may be negative, which is ok for now
+	percent = 100*((data[data.length-1][p] - data[0][p]) / data[0][p]);
+  } else if (data[data.length-1][p] > 0) { 
+    //special case where change is from 0 to anything other than 0
+	percent = 100;
+  }
+  return percent;
+};
+
+function getTimePeriod(data) {
+  //may be negative, which is ok for now
+  let period = "";
+  switch(data.length) {
+	case 25: 
+		period = "day";
+		break;
+	
+	case 169:
+		period = "week";
+		break;
+	
+	default:
+		period = "month";
+		break;	
+  
+  }
+
+  return period;
+};
+
+function indicatorText(value){
+  let indicatorColour,
+      indicatorText,
+	  directionText,
+      indicatorSymbol = value > 0 ? " ▲ " : value < 0 ? " ▼ " : " ";
+
+  directionText = value < 0 ? "fewer than it was " : value > 0 ? "greater than it was " : " no change from ";
+
+	
+  indicatorText = "" + Math.abs(value) + "% " + indicatorSymbol + directionText;
+      
+  return indicatorText;
+}
+
+function setIndicatorColour(value, selector) {
+	
+	  if(value < 0 ){
+      indicatorColour = value < 0 ? "#da1e4d" : value > 0 ? "#20c997" : "#f8f8f8";
+  }
+  else{
+      indicatorColour = value > 0 ? "#20c997" : value < 0 ? "#da1e4d" : "#f8f8f8";
+  }
+  
+  d3.select(selector).style("color", indicatorColour);
+}
+
+function getPreviousTime(data) {
+  let previous = "";
+  switch(data.length) {
+	case 25: 
+		previous = "yesterday";
+		break;
+	
+	case 169:
+		previous = "one week ago";
+		break;
+	
+	default:
+		previous = "one month ago";
+		break;	
+  
+  }
+  return previous;
 };

--- a/views/themes_transport_charts.pug
+++ b/views/themes_transport_charts.pug
@@ -1,7 +1,7 @@
 header
   .row
     .col-12
-      h1 Transport_Test
+      h1 Transport
       p.lead Transport and travel data for Dublin
       // is available for the Airport <i>(coming soon)</i>, 
         |Bike Hire, Bus, Luas, Port <i>(coming soon)</i>, Tram, and Private Car Parking.
@@ -28,7 +28,8 @@ article.article
         |click on a button to move between views.
 
       div#bikes-info-text
-        p In the past day, the maximum number of bikes in use at any given time was <b id='bikes-in-use-count'></b> at <b id='max-bikes-use-time'></b>, meaning there were then still <b id='bikes-available'></b> bikes available.
+        p In the past <b id='time-period'></b>, the maximum number of bikes in use at any given time was <b id='bikes-in-use-count'></b> at <b id='max-bikes-use-time'></b>, meaning there were then still <b id='bikes-available'></b> bikes available.
+        p The current <b id='current-bikes-in-use-count'></b> bikes in use is <b id='percent-change-with-indicator'></b>  <b id='previous-time'></b>.
 
         //- bike stations around 
         //-   |the city with <b id='stands-count'></b> stands.


### PR DESCRIPTION
App.js
Bikes API get is now scheduled for every 30 minutes
  --is now scheduled to get last day/week/month + 1 ("1 day ago at this time")

transport_dublinbikes.js
Added methods to get rate of change in bikes in use over the last day/week/month and update the .pug on button click

themes_transport_charts.pug
Added additional text for rate of change in bikes in use over last day/week/month

derilinx-api-query.js
Changed logic for finding total bikes:
  instead of assuming method call at 3 am, pre-query dublinbikes API at the most recent 3 am once. Get bikes available.
  Possible solution to Issues #45 and #77

Logging new issue: moment.js converts dublinbikes API response time to local time